### PR TITLE
Fix some data_type column migrations

### DIFF
--- a/schema/1_root.sql
+++ b/schema/1_root.sql
@@ -1,2 +1,18 @@
--- This needs root and likely will have to be applied manually:
-UPDATE pg_enum SET enumlabel = 'numeric' WHERE enumtypid = 'data_type'::regtype::oid AND enumlabel = 'number';
+-- Rename data_type value: number -> numeric
+
+-- Create a new enum, replacing 'number' with 'numeric'
+CREATE TYPE data_type_new AS ENUM ('text', 'numeric', 'date');
+COMMENT ON TYPE data_type_new
+  IS 'Types of measurement data corresponding to measure_* tables.';
+-- Update all relevant tables to change column type from old enum to new enum,
+-- replacing 'number' with 'numeric' and casting the other values
+ALTER TABLE "metric"
+  ALTER COLUMN "type" TYPE data_type_new
+  USING CASE
+    WHEN "type" = 'number' THEN 'numeric'  -- Replace
+    ELSE "type"::text::data_type_new       -- Cast
+  END;
+-- Drop old enum
+DROP TYPE data_type;
+-- Rename new enum
+ALTER TYPE data_type_new RENAME TO data_type;

--- a/schema/20150728-void_type.sql
+++ b/schema/20150728-void_type.sql
@@ -1,1 +1,15 @@
-ALTER TYPE data_type ADD VALUE 'void';
+-- Add data_type value: void
+
+-- Create a new enum, extended with 'void'
+CREATE TYPE data_type_new AS ENUM ('text', 'numeric', 'date', 'void');
+COMMENT ON TYPE data_type_new
+  IS 'Types of measurement data corresponding to measure_* tables.';
+-- Update all relevant tables to change column type from old enum to new enum,
+-- casting the values
+ALTER TABLE "metric"
+  ALTER COLUMN "type" TYPE data_type_new
+  USING "type"::text::data_type_new;    -- Cast
+-- Drop old enum
+DROP TYPE data_type;
+-- Rename new enum
+ALTER TYPE data_type_new RENAME TO data_type;


### PR DESCRIPTION
I was unable to run the schema migrations from beginning to end due to the following problems:

1. `1_root` required superuser privilege to run.
2. `20150728-void_type` would not run in a transaction.

This PR fixes both. Since they are very similar (changing the values of the enum `data_type`), the migrations look similar.