### PR TITLE
Remove selector format joins rebase off dev (rebase 2)

### DIFF
--- a/Databrary/Model/Asset.hs
+++ b/Databrary/Model/Asset.hs
@@ -17,6 +17,7 @@ import Data.Maybe (isNothing, isJust)
 import Data.Monoid ((<>))
 import qualified Data.Text as T
 import Database.PostgreSQL.Typed (pgSQL)
+import Database.PostgreSQL.Typed.Query (makePGQuery, QueryFlags(..), simpleQueryFlags)
 
 import Databrary.Ops
 import Databrary.Has (view, peek)
@@ -32,9 +33,12 @@ import Databrary.Model.Id
 import Databrary.Model.Identity
 import Databrary.Model.Party
 import Databrary.Model.Volume
+import Databrary.Model.Volume.SQL (makeVolume, setCreation)
 import Databrary.Model.Format
 import Databrary.Model.Asset.Types
 import Databrary.Model.Asset.SQL
+
+$(useTDB)
 
 blankAsset :: Volume -> Asset
 blankAsset vol = Asset
@@ -56,9 +60,24 @@ assetBacked = isJust . assetSHA1 . assetRow
 lookupAsset :: (MonadHasIdentity c m, MonadDB c m) => Id Asset -> m (Maybe Asset)
 lookupAsset ai = do
   ident <- peek
-  dbQuery1 $(selectQuery (selectAsset 'ident) "$WHERE asset.id = ${ai}")
+  mRow <- dbQuery1
+      $(makePGQuery
+          (simpleQueryFlags { flagPrepare = Just [] })
+          (   "SELECT asset.id,asset.format,asset.release,asset.duration,asset.name,asset.sha1,asset.size,volume.id,volume.name,volume.body,volume.alias,volume.doi,volume_creation(volume.id),volume_owners.owners,volume_permission.permission"
+           ++ " FROM asset JOIN volume LEFT JOIN volume_owners ON volume.id = volume_owners.volume JOIN LATERAL (VALUES (CASE WHEN ${identitySuperuser ident} THEN enum_last(NULL::permission) ELSE volume_access_check(volume.id, ${view ident :: Id Party}) END)) AS volume_permission (permission) ON volume_permission.permission >= 'PUBLIC'::permission ON asset.volume = volume.id "
+           ++ "WHERE asset.id = ${ai}" ))
+  pure 
+    (fmap 
+       (\(aid,afm,arl,adr,anm,ash,asz,vid,vnm,vbd,vals,vdoi,vcr,vow,vpr) -> 
+          ($)
+            (Asset (makeAssetRow aid afm arl adr anm ash asz))
+            (makeVolume
+              (setCreation (VolumeRow vid vnm vbd vals vdoi) vcr)
+              vow
+              vpr))
+       mRow)
 
-lookupVolumeAsset :: (MonadDB c m) => Volume -> Id Asset -> m (Maybe Asset)
+lookupVolumeAsset :: (MonadDB c m) => Volume -> Id Asset -> m (Maybe Asset) -- TODO: expand soon
 lookupVolumeAsset vol ai = do
   dbQuery1 $ (`Asset` vol) <$> $(selectQuery selectAssetRow "WHERE asset.id = ${ai} AND asset.volume = ${volumeId $ volumeRow vol}")
 

--- a/Databrary/Model/Asset/SQL.hs
+++ b/Databrary/Model/Asset/SQL.hs
@@ -4,6 +4,7 @@ module Databrary.Model.Asset.SQL
   , selectAsset
   , insertAsset
   , updateAsset
+  , makeAssetRow -- TODO: move to Types
   ) where
 
 import qualified Data.ByteString as BS

--- a/Databrary/Model/AssetSlot/SQL.hs
+++ b/Databrary/Model/AssetSlot/SQL.hs
@@ -2,15 +2,15 @@
 module Databrary.Model.AssetSlot.SQL
   ( slotAssetRow
   , makeSlotAsset
-  , selectContainerSlotAsset
   , selectAssetSlotAsset
   , selectVolumeSlotAsset
-  , selectVolumeSlotIdAsset
   , selectSlotAsset
   , selectAssetSlot
   , insertSlotAsset
   , updateSlotAsset
   , deleteSlotAsset
+  , makeContainerSlotAsset -- TODO: Move these to Types
+  , makeVolumeSlotIdAsset 
   ) where
 
 import Data.Maybe (fromMaybe)
@@ -41,22 +41,8 @@ _selectAssetContainerSlotAsset = selectMap (TH.VarE 'makeSlotAsset `TH.AppE`) sl
 makeContainerSlotAsset :: Segment -> AssetRow -> Container -> AssetSlot
 makeContainerSlotAsset s ar c = makeSlotAsset (Asset ar $ view c) c s
 
-selectContainerSlotAsset :: Selector -- ^ @'Container' -> 'AssetSlot'@
-selectContainerSlotAsset = selectJoin 'makeContainerSlotAsset
-  [ slotAssetRow
-  , joinOn "slot_asset.asset = asset.id"
-    selectAssetRow -- XXX volumes match?
-  ]
-
 makeVolumeSlotIdAsset :: SlotId -> AssetRow -> Volume -> (Asset, SlotId)
 makeVolumeSlotIdAsset s ar v = (Asset ar v, s)
-
-selectVolumeSlotIdAsset :: Selector -- ^ @'Volume' -> ('Asset', 'SlotId')@
-selectVolumeSlotIdAsset = selectJoin 'makeVolumeSlotIdAsset
-  [ selectColumns 'SlotId "slot_asset" ["container", "segment"]
-  , joinOn "slot_asset.asset = asset.id"
-    selectAssetRow -- XXX volumes match?
-  ]
 
 makeAssetSlotAsset :: Segment -> (Volume -> Container) -> Asset -> AssetSlot
 makeAssetSlotAsset s cf a = makeSlotAsset a (cf (view a)) s

--- a/Databrary/Model/Container/SQL.hs
+++ b/Databrary/Model/Container/SQL.hs
@@ -24,7 +24,7 @@ selectVolumeContainer = selectJoin 'Container
     (selectColumn "slot_release" "release")
   ]
 
-selectContainer :: TH.Name -- ^ @'Identity'@
+selectContainer :: TH.Name -- ^ @'Identity'@  -- only used by Comment now
   -> Selector -- ^ @'Container'@
 selectContainer ident = selectJoin '($)
   [ selectVolumeContainer

--- a/Databrary/Model/Excerpt/SQL.hs
+++ b/Databrary/Model/Excerpt/SQL.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Databrary.Model.Excerpt.SQL
-  ( -- selectAssetSlotExcerpt
-    makeExcerpt
-  , selectContainerExcerpt
+  ( makeExcerpt
+  , makeAssetContainerExcerpt
+  , makeContainerExcerpt -- TODO: this and above to Types
   , selectVolumeExcerpt
   , insertExcerpt
   , updateExcerpt
@@ -32,20 +32,13 @@ makeAssetContainerExcerpt as e a c = e $ makeSlotAsset a c as
 
 selectAssetContainerExcerpt :: Selector -- ^ @'Asset' -> 'Container' -> 'Excerpt'@
 selectAssetContainerExcerpt = selectJoin 'makeAssetContainerExcerpt
-  [ slotAssetRow
+  [ selectColumn "slot_asset" "segment"
   , joinOn "slot_asset.asset = excerpt.asset"
     (selectColumns 'makeExcerpt "excerpt" ["segment", "release"])
   ]
 
 makeContainerExcerpt :: (Asset -> Container -> Excerpt) -> AssetRow -> Container -> Excerpt
 makeContainerExcerpt f ar c = f (Asset ar (containerVolume c)) c
-
-selectContainerExcerpt :: Selector -- ^ @'Container' -> 'Excerpt'@
-selectContainerExcerpt = selectJoin 'makeContainerExcerpt
-  [ selectAssetContainerExcerpt
-  , joinOn "slot_asset.asset = asset.id"
-    selectAssetRow -- XXX volumes match?
-  ]
 
 makeVolumeExcerpt :: (Asset -> Container -> Excerpt) -> AssetRow -> (Volume -> Container) -> Volume -> Excerpt
 makeVolumeExcerpt f ar cf v = f (Asset ar v) (cf v)
@@ -54,7 +47,7 @@ selectVolumeExcerpt :: Selector -- ^ @'Volume' -> 'Excerpt'@
 selectVolumeExcerpt = selectJoin 'makeVolumeExcerpt
   [ selectAssetContainerExcerpt
   , joinOn "slot_asset.asset = asset.id"
-    selectAssetRow
+     (selectColumns 'makeAssetRow "asset" ["id", "format", "release", "duration", "name", "sha1", "size"])
   , joinOn "slot_asset.container = container.id AND asset.volume = container.volume"
     selectVolumeContainer
   ]

--- a/Databrary/Model/Funding/SQL.hs
+++ b/Databrary/Model/Funding/SQL.hs
@@ -1,19 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Databrary.Model.Funding.SQL
-  ( selectVolumeFunding
+  ( makeFunding -- TODO: move to Types
   ) where
 
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 
-import Databrary.Model.SQL.Select
 import Databrary.Model.Funding.Types
 
 makeFunding :: [Maybe T.Text] -> Funder -> Funding
 makeFunding a f = Funding f (map (fromMaybe (error "NULL funding.award")) a)
-
-selectVolumeFunding :: Selector -- ^ @'Funding'@
-selectVolumeFunding = selectJoin '($)
-  [ selectColumns 'makeFunding "volume_funding" ["awards"]
-  , joinOn "volume_funding.funder = funder.fundref_id" (selectColumns 'Funder "funder" ["fundref_id", "name"])
-  ]

--- a/Databrary/Model/Tag/SQL.hs
+++ b/Databrary/Model/Tag/SQL.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Databrary.Model.Tag.SQL
-  ( selectTagUseRow
-  , insertTagUse
+  ( insertTagUse
   , deleteTagUse
   , selectTagWeight
   , selectTagCoverage
   , selectSlotTagCoverage
+  , makeTagUseRow -- TODO: move to Types
   ) where
 
 import Data.List (intercalate)
@@ -27,26 +27,6 @@ tagUseTable True = "keyword_use"
 
 makeTagUseRow :: Id Party -> Id Container -> Segment -> Maybe Bool -> Tag -> TagUseRow
 makeTagUseRow w c s k t = TagUseRow t (fromMaybe False k) w (SlotId c s)
-
-tagUseRow :: Selector -- ' @'Tag' -> 'TagUseRow'@
-tagUseRow = 
-  Selector {
-    selectOutput = 
-      OutputJoin 
-        False 
-        '($) 
-        (selectOutput (selectColumns 'makeTagUseRow "tag_use" ["who", "container", "segment"])
-         : [SelectExpr "tag_use.tableoid = 'keyword_use'::regclass"])
-  , selectSource = "tag_use"
-  , selectJoined = ",tag_use"
-  }
-
-selectTagUseRow :: Selector -- ^ @'TagUseId'@
-selectTagUseRow = selectJoin '($)
-  [ tagUseRow
-  , joinOn "tag_use.tag = tag.id"
-    (selectColumns 'Tag "tag" ["id", "name"])
-  ]
 
 insertTagUse :: Bool -- ^ keyword
   -> TH.Name -- ^ @'TagUse'@

--- a/Databrary/Model/Transcode/SQL.hs
+++ b/Databrary/Model/Transcode/SQL.hs
@@ -2,6 +2,8 @@
 module Databrary.Model.Transcode.SQL
   ( selectOrigTranscode
   , selectTranscode
+  , makeTranscodeRow -- TODO: move to types
+  , makeOrigTranscode
   ) where
 
 import qualified Data.ByteString as BS
@@ -40,7 +42,7 @@ selectOrigTranscode :: Selector -- ^ @'Asset' -> 'Transcode'@
 selectOrigTranscode = selectJoin 'makeOrigTranscode
   [ selectAssetRevisionTranscode
   , joinOn "transcode.asset = asset.id"
-    selectAssetRow
+    (selectColumns 'makeAssetRow "asset" ["id", "format", "release", "duration", "name", "sha1", "size"])
   ]
 
 makeTranscode :: (Asset -> Transcode) -> AssetRow -> (Permission -> Volume) -> Transcode

--- a/Databrary/Model/Volume.hs
+++ b/Databrary/Model/Volume.hs
@@ -21,6 +21,7 @@ import Data.Monoid ((<>))
 import qualified Data.Text as T
 import Database.PostgreSQL.Typed.Query (pgSQL, unsafeModifyQuery)
 import Database.PostgreSQL.Typed.Dynamic (pgLiteralRep)
+import Database.PostgreSQL.Typed.Query (makePGQuery, QueryFlags(..), simpleQueryFlags)
 
 import Databrary.Has (peek, view)
 import Databrary.Service.DB
@@ -36,13 +37,28 @@ import Databrary.Model.Volume.Types
 import Databrary.Model.Volume.SQL
 import Databrary.Model.Volume.Boot
 
+$(useTDB)
+
 coreVolume :: Volume
 coreVolume = $(loadVolume (Id 0))
 
 lookupVolume :: (MonadDB c m, MonadHasIdentity c m) => Id Volume -> m (Maybe Volume)
 lookupVolume vi = do
   ident :: Identity <- peek
-  dbQuery1 $(selectQuery (selectVolume 'ident) "$WHERE volume.id = ${vi}")
+  rows <- dbQuery1
+      $(makePGQuery
+          (simpleQueryFlags { flagPrepare = Just [] })
+          (   "SELECT volume.id,volume.name,volume.body,volume.alias,volume.doi,volume_creation(volume.id),volume_owners.owners,volume_permission.permission"
+           ++ " FROM volume LEFT JOIN volume_owners ON volume.id = volume_owners.volume JOIN LATERAL (VALUES (CASE WHEN ${identitySuperuser ident} THEN enum_last(NULL::permission) ELSE volume_access_check(volume.id, ${view ident :: Id Party}) END)) AS volume_permission (permission) ON volume_permission.permission >= 'PUBLIC'::permission "
+           ++ " WHERE volume.id = ${vi} " ))
+  pure 
+    (fmap 
+       (\(vid, nm, bd, als, doi, cr, own, prm) -> 
+          makeVolume
+            (setCreation (VolumeRow vid nm bd als doi) cr)
+            own
+            prm)
+       rows)
 
 changeVolume :: MonadAudit c m => Volume -> m ()
 changeVolume v = do
@@ -106,8 +122,19 @@ volumeFilter VolumeFilter{..} = BS.concat
 findVolumes :: (MonadHasIdentity c m, MonadDB c m) => VolumeFilter -> m [Volume]
 findVolumes pf = do
   ident <- peek
-  dbQuery $ unsafeModifyQuery $(selectQuery (selectVolume 'ident) "")
-    (<> volumeFilter pf)
+  rows <- dbQuery
+    (unsafeModifyQuery
+      $(makePGQuery
+          (simpleQueryFlags { flagPrepare = Just [] })
+          (   "SELECT volume.id,volume.name,volume.body,volume.alias,volume.doi,volume_creation(volume.id),volume_owners.owners,volume_permission.permission"
+           ++ " FROM volume LEFT JOIN volume_owners ON volume.id = volume_owners.volume JOIN LATERAL (VALUES (CASE WHEN ${identitySuperuser ident} THEN enum_last(NULL::permission) ELSE volume_access_check(volume.id, ${view ident :: Id Party}) END)) AS volume_permission (permission) ON volume_permission.permission >= 'PUBLIC'::permission "
+           ++ ""))
+      (<> volumeFilter pf))
+  pure 
+    (fmap 
+       (\(vid, nm, bd, als, doi, cr, own, prm) -> 
+          makeVolume (setCreation (VolumeRow vid nm bd als doi) cr) own prm)
+       rows)
 
 updateVolumeIndex :: MonadDB c m => m ()
 updateVolumeIndex =

--- a/Databrary/Model/Volume/SQL.hs
+++ b/Databrary/Model/Volume/SQL.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell, OverloadedStrings #-}
 module Databrary.Model.Volume.SQL
   ( selectVolumeRow
+  , setCreation
+  , makeVolume -- TODO: move to Types
   , selectPermissionVolume
   , selectVolume
   , updateVolume


### PR DESCRIPTION
Unroll the "Selector" abstraction used to generate join queries, for some selected queries. Eventually finish this for all others, when time allows.

Merge after automated test run. I will start testing more intensely on my dev instance soon, so I can merge into develop branch first, then deploy from develop branch onto dev2.