### PR TITLE
Add ability to use smtp-mail instead - in progress

### DIFF
--- a/databrary.cabal
+++ b/databrary.cabal
@@ -149,7 +149,8 @@ Executable databrary
     zlib,
     range-set-list,
     invertible,
-    web-inv-route
+    web-inv-route,
+    smtp-mail >= 0.1.0.0
 
   default-language: Haskell2010
   default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards


### PR DESCRIPTION
Simply cherry-picking Ali's earlier work on Obsidian branch.
Modify credentials to use gsuite smtp on dev server.
Test sending some emails.
Update default config to use new method of sending emails.
(Generate temporary executable for testing on stage server, run test, then merge this branch).