### PR TITLE
Invoke schemabrary explicitly during build from shell script instead of cabal custom

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -25,14 +25,18 @@ import System.FilePath ((<.>), (</>))
 import Databrary.Setup.Git
 import Databrary.Setup.Node
 
+{-
 run :: Verbosity -> PackageDescription -> LocalBuildInfo -> String -> [String] -> IO ()
 run verb desc lbi cmd args = do
   env <- getEnvironment
   cwd <- getCurrentDirectory
+  print ("running ", show $ buildDir lbi </> cmd </> cmd <.> exeExtension)
+  print ("with datadir ", show $ cwd </> dataDir desc)
   rawSystemExitWithEnv verb (buildDir lbi </> cmd </> cmd <.> exeExtension) args
     $ (pkgPathEnvVar desc "datadir", cwd </> dataDir desc)
     : (pkgPathEnvVar desc "sysconfdir", cwd)
     : env
+-}
 
 -- chmod +x on transctl.sh and transcode scripts
 {-
@@ -69,9 +73,11 @@ main = defaultMainWithHooks simpleUserHooks
     nodeModuleGenerate verb desc lbi
     let args = buildArgs flag
         build c = buildHook simpleUserHooks desc lbi hooks flag{ buildArgs = c }
+    {-
     when (null args) $ do
       build ["schemabrary"]
       run verb desc lbi "schemabrary" []
+    -}
     build args
     {- after build bundle all the web assets and js (that's the -w flag)
     -}

--- a/dev
+++ b/dev
@@ -11,15 +11,19 @@ echo "========Configuring build settings========================================
 echo "========Download lastest node dependencies====================================================="
 cabal configure --user
 
+build_user=`whoami`
 echo "========Build Setup script into dist/setup/setup==============================================="
 echo "========Determine version from git commit======================================================"
 echo "========Download lastest node dependencies====================================================="
-echo "========Run any DB Migrations=================================================================="
+echo "========Run DB Migrations on build db=========================================================="
+cabal build schemabrary
+distbuild_dir="dist/build"
+yes | databrary_datadir="." $distbuild_dir/schemabrary/schemabrary
+
 echo "========Build into dist/build=================================================================="
 echo "========Add version suffix to executable name=================================================="
 cabal install
 echo "========Generate web assets===================================================================="
-build_user=`whoami`
 exe_dir="/home/$build_user/.cabal/bin"
 data_basedir="/home/$build_user/.cabal/share/x86_64-linux-ghc-7.10.3"
 data_outputdir="$data_basedir/databrary-1"

--- a/dev
+++ b/dev
@@ -12,14 +12,12 @@ echo "========Download lastest node dependencies================================
 cabal configure --user
 
 build_user=`whoami`
-echo "========Build Setup script into dist/setup/setup==============================================="
-echo "========Determine version from git commit======================================================"
-echo "========Download lastest node dependencies====================================================="
 echo "========Run DB Migrations on build db=========================================================="
 cabal build schemabrary
 distbuild_dir="dist/build"
 yes | databrary_datadir="." $distbuild_dir/schemabrary/schemabrary
-
+echo "========Determine version from git commit======================================================"
+echo "========Download lastest node dependencies====================================================="
 echo "========Build into dist/build=================================================================="
 echo "========Add version suffix to executable name=================================================="
 cabal install

--- a/dev
+++ b/dev
@@ -16,7 +16,6 @@ echo "========Determine version from git commit=================================
 echo "========Download lastest node dependencies====================================================="
 echo "========Run any DB Migrations=================================================================="
 echo "========Build into dist/build=================================================================="
-echo "========Set transcode scripts as executable===================================================="
 echo "========Add version suffix to executable name=================================================="
 cabal install
 echo "========Generate web assets===================================================================="
@@ -30,6 +29,7 @@ databrary_datadir="." $built_exe -w
 pushd web
 cp all.min.css all.min.css.gz all.min.js all.min.js.gz constants.json constants.json.gz $data_outputwebdir/
 popd
+echo "========Set transcode scripts as executable===================================================="
 cp transcode transctl.sh $data_outputdir
 chmod +x $data_outputdir/transcode $data_outputdir/transctl.sh
 echo "========The prefix of this version will provide you with the version built: `git describe`====="


### PR DESCRIPTION
Below is output from tracing the old behavior
```
Preprocessing executable 'schemabrary' for databrary-1.3.1.173...
[1 of 6] Compiling Databrary.Ops    ( Databrary/Ops.hs, dist/dist-sandbox-6f53520f/build/schemabrary/schemabrary-tmp/Databrary/Ops.o )
...
Linking dist/dist-sandbox-6f53520f/build/schemabrary/schemabrary ...
("running ","\"dist/dist-sandbox-6f53520f/build/schemabrary/schemabrary\"")
("with datadir ","\"/home/kanishka/src/databrary\"")
```

Although running says "dist-sandbox-... above, when attempting to invoke such maually, nothing is present at that time in the build. Instead I used dist/build/schemabrary directory. 

FYI: @muji786  Note this change in the build, so someone besides me knows this happened.