### PR TITLE
Kanishka dev explicit migrate

### DIFF
--- a/dev
+++ b/dev
@@ -13,6 +13,7 @@ cabal configure --user
 
 build_user=`whoami`
 echo "========Run DB Migrations on build db=========================================================="
+conf_exists=`ls databrary.conf`
 cabal build schemabrary
 distbuild_dir="dist/build"
 yes | databrary_datadir="." $distbuild_dir/schemabrary/schemabrary

--- a/pull-migrate-build-start.sh
+++ b/pull-migrate-build-start.sh
@@ -30,8 +30,9 @@ echo "=== Run new db migrations on build db, build, install"
 ./dev
 built_exe=`ls -t $exe_dir/databrary-* | head -1` #extract exact version from git describe instead
 
-echo "=== Run new db migrations on live db, starting $built_exe"
+echo "=== Run new db migrations on live db"
 conf_exists=`ls databrary.conf`
 built_schemabrary=`ls -t $exe_dir/schemabrary-* | head -1`
-databrary_datadir="$data_basedir/databrary-1" $built_schemabrary
+yes | databrary_datadir="$data_basedir/databrary-1" $built_schemabrary
+echo "=== Starting $built_exe"
 databrary_datadir="$data_basedir/databrary-1" $built_exe

--- a/pull-migrate-build-start.sh
+++ b/pull-migrate-build-start.sh
@@ -26,10 +26,12 @@ echo "=== Stash, pull latest from $branch"
 git stash save # need in case there were manual, conflicting changes that would prevent pulling from succeeding
 git pull
 
-echo "=== Run new db migrations, build, install"
+echo "=== Run new db migrations on build db, build, install"
 ./dev
 built_exe=`ls -t $exe_dir/databrary-* | head -1` #extract exact version from git describe instead
 
-echo "=== Starting $built_exe"
+echo "=== Run new db migrations on live db, starting $built_exe"
 conf_exists=`ls databrary.conf`
-databrary_datadir="$data_basedir/databrary-1" `$built_exe`
+built_schemabrary=`ls -t $exe_dir/schemabrary-* | head -1'
+databrary_datadir="$data_basedir/databrary-1" $built_schemabrary
+databrary_datadir="$data_basedir/databrary-1" $built_exe

--- a/pull-migrate-build-start.sh
+++ b/pull-migrate-build-start.sh
@@ -32,6 +32,6 @@ built_exe=`ls -t $exe_dir/databrary-* | head -1` #extract exact version from git
 
 echo "=== Run new db migrations on live db, starting $built_exe"
 conf_exists=`ls databrary.conf`
-built_schemabrary=`ls -t $exe_dir/schemabrary-* | head -1'
+built_schemabrary=`ls -t $exe_dir/schemabrary-* | head -1`
 databrary_datadir="$data_basedir/databrary-1" $built_schemabrary
 databrary_datadir="$data_basedir/databrary-1" $built_exe


### PR DESCRIPTION
Repeat this change for staging and prod scripts soon. This explicitly runs db migrations before starting new version of application. Before this was implicit on application startup. Eventually, there will be a script `restart-upgrading.sh` which will perform stop, run db migrations, start.

FYI: @muji786 this changed on dev site, it will change on staging/prod soon after.