### PR TITLE
Create unit test suites that match the future cabal libs

### DIFF
--- a/Databrary/Service/Mail.hs
+++ b/Databrary/Service/Mail.hs
@@ -2,6 +2,8 @@
 module Databrary.Service.Mail
   ( MonadMail
   , sendMail
+  -- below for testing
+  , wrapText
   ) where
 
 import Control.Monad.IO.Class (liftIO)

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -59,7 +59,303 @@ Flag sandbox
   default: False
   manual: True
 
-test-suite unit-test
+test-suite dbrary-env-unit-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test/unit, .
+  main-is: DbraryEnvUnitTest.hs
+  other-modules:
+      Databrary.Store.Config
+    , Databrary.Store.ConfigTest
+  build-depends: 
+    base == 4.8.*,
+    bytestring >= 0.10,
+    -- containers,
+    -- array,
+    -- transformers == 0.4.*,
+    -- transformers-base,
+    -- mtl >= 2.2.1,
+    -- monad-control >= 1,
+    -- lifted-base,
+    -- template-haskell,
+    -- th-lift,
+    -- th-lift-instances,
+    -- haskell-src-meta,
+    -- time,
+    -- unix,
+    -- filepath,
+    -- posix-paths,
+    -- directory,
+    -- process,
+    -- data-default-class,
+    text,
+    -- utf8-string,
+    -- hashable >= 1.2.1,
+    unordered-containers,
+    parsec >= 3,
+    -- attoparsec,
+    -- network,
+    -- network-uri,
+    -- http-types,
+    -- wai,
+    -- wai-extra,
+    -- warp,
+    -- warp-tls,
+    -- case-insensitive,
+    aeson,
+    vector,
+    -- cookie,
+    -- resource-pool,
+    -- scientific,
+    -- postgresql-typed == 0.4.5,
+    -- memory >= 0.8,
+    -- cryptonite,
+    -- resourcet,
+    -- streaming-commons,
+    -- blaze-builder >= 0.4,
+    -- blaze-markup,
+    -- blaze-html,
+    -- regex-posix,
+    -- bcrypt,
+    -- http-client,
+    -- http-client-tls,
+    -- mime-mail,
+    -- fast-logger,
+    -- digest,
+    -- hjsonschema == 0.9.*,
+    -- file-embed == 0.0.9.1,
+    -- aeson-better-errors > 0.9.0,
+    -- xml,
+    -- zlib,
+    -- range-set-list,
+    -- invertible,
+    -- web-inv-route,
+    tasty,
+    tasty-hunit
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
+
+test-suite dbrary-mail-unit-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test/unit, .
+  main-is: DbraryMailUnitTest.hs
+  other-modules:
+      Databrary.Service.Mail
+    -- mail brings in many modules, not listed below
+    , Databrary.Service.MailTest
+  build-depends: 
+    base == 4.8.*,
+    bytestring >= 0.10,
+    containers,
+    transformers == 0.4.*,
+    transformers-base,
+    mtl >= 2.2.1,
+    monad-control >= 1,
+    lifted-base,
+    template-haskell,
+    th-lift,
+    th-lift-instances,
+    time,
+    posix-paths,
+    data-default-class,
+    text,
+    utf8-string,
+    hashable >= 1.2.1,
+    unordered-containers,
+    parsec >= 3,
+    network,
+    network-uri,
+    http-types,
+    wai,
+    wai-extra,
+    case-insensitive,
+    aeson,
+    vector,
+    resource-pool,
+    scientific,
+    postgresql-typed == 0.4.5,
+    blaze-markup,
+    blaze-html,
+    mime-mail,
+    fast-logger,
+    web-inv-route,
+    tasty,
+    tasty-hunit
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
+
+test-suite dbrary-authent-unit-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test/unit, .
+  main-is: DbraryAuthentUnitTest.hs
+  other-modules:
+      Databrary.Service.Passwd
+    , Databrary.Service.PasswdTest
+  build-depends: 
+    base == 4.8.*,
+    bytestring >= 0.10,
+    bcrypt,
+    tasty,
+    tasty-hunit
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
+  extra-libraries: crack
+
+test-suite dbrary-solr-unit-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test/unit, .
+  main-is: DbrarySolrUnitTest.hs
+  other-modules:
+              Databrary.Solr.Service
+            , Databrary.Solr.ServiceTest
+  build-depends: 
+    base == 4.8.*,
+    bytestring >= 0.10,
+    containers,
+    -- array,
+    transformers == 0.4.*,
+    transformers-base,
+    mtl >= 2.2.1,
+    monad-control >= 1,
+    lifted-base,
+    template-haskell,
+    th-lift,
+    -- th-lift-instances,
+    -- haskell-src-meta,
+    time,
+    -- unix,
+    filepath,
+    -- posix-paths,
+    directory,
+    process,
+    -- data-default-class,
+    text,
+    utf8-string,
+    -- hashable >= 1.2.1,
+    unordered-containers,
+    parsec >= 3,
+    attoparsec,
+    network,
+    network-uri,
+    http-types,
+    wai,
+    wai-extra,
+    -- warp,
+    -- warp-tls,
+    case-insensitive,
+    aeson,
+    vector,
+    -- cookie,
+    resource-pool,
+    scientific,
+    postgresql-typed == 0.4.5,
+    -- memory >= 0.8,
+    -- cryptonite,
+    -- resourcet,
+    -- streaming-commons,
+    -- blaze-builder >= 0.4,
+    blaze-markup,
+    blaze-html,
+    -- regex-posix,
+    -- bcrypt,
+    http-client,
+    http-client-tls,
+    -- mime-mail,
+    -- fast-logger,
+    -- digest,
+    -- hjsonschema == 0.9.*,
+    -- file-embed == 0.0.9.1,
+    -- aeson-better-errors > 0.9.0,
+    -- xml,
+    -- zlib,
+    range-set-list,
+    -- invertible,
+    web-inv-route,
+    tasty,
+    tasty-hunit
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
+
+test-suite dbrary-store-unit-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test/unit, .
+  main-is: DbraryStoreUnitTest.hs
+  other-modules:
+      Databrary.Files
+    , Databrary.Store.Filename
+    , Databrary.Store.Asset
+    , Databrary.Store.Types
+    , Databrary.Store.Stage
+    , Databrary.Store.Temp
+    , Databrary.Store.Upload
+    , Databrary.Store.Zip
+    -- AV is only here to enable building
+    , Databrary.Store.AV
+    , Databrary.FilesTest
+  c-sources: Databrary/Store/avFrame.c
+  build-depends: 
+    base == 4.8.*,
+    bytestring >= 0.10,
+    containers,
+    array,
+    transformers == 0.4.*,
+    transformers-base,
+    mtl >= 2.2.1,
+    monad-control >= 1,
+    lifted-base,
+    template-haskell,
+    th-lift,
+    th-lift-instances,
+    time,
+    unix,
+    filepath,
+    posix-paths,
+    directory,
+    process,
+    data-default-class,
+    text,
+    utf8-string,
+    hashable >= 1.2.1,
+    unordered-containers,
+    parsec >= 3,
+    attoparsec,
+    network,
+    network-uri,
+    http-types,
+    wai,
+    wai-extra,
+    case-insensitive,
+    aeson,
+    vector,
+    cookie,
+    resource-pool,
+    scientific,
+    postgresql-typed == 0.4.5,
+    memory >= 0.8,
+    cryptonite,
+    resourcet,
+    blaze-markup,
+    blaze-html,
+    regex-posix,
+    bcrypt,
+    http-client,
+    http-client-tls,
+    fast-logger,
+    digest,
+    invertible,
+    web-inv-route,
+    tasty,
+    tasty-hunit
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
+  pkgconfig-depends: libavformat, libswscale, libavcodec, libavutil
+  extra-libraries: crack
+
+test-suite dbrary-unit-test
   type: exitcode-stdio-1.0
   hs-source-dirs: test/unit, .
   main-is: UnitTest.hs
@@ -70,7 +366,6 @@ test-suite unit-test
          , Databrary.OpsTest
          , Databrary.Model.TimeTest
          , Databrary.StringTest
-
          , Data.RangeSet.Parse
          , Databrary.EZID.ANVL
          , Databrary.Model.Time
@@ -139,7 +434,6 @@ test-suite unit-test
     range-set-list,
     -- invertible,
     -- web-inv-route,
-
     tasty,
     tasty-hunit
   ghc-options: -threaded -rtsopts -with-rtsopts=-N

--- a/test/unit/Databrary/FilesTest.hs
+++ b/test/unit/Databrary/FilesTest.hs
@@ -1,0 +1,22 @@
+module Databrary.FilesTest
+   ( tests )
+where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Databrary.Files
+import Databrary.Store.Filename
+import Databrary.Store.Asset
+import Databrary.Store.Types
+import Databrary.Store.Stage
+import Databrary.Store.Temp
+import Databrary.Store.Upload
+import Databrary.Store.Zip
+
+tests :: TestTree
+tests = testGroup "Databrary.Files"
+  [ testCase "rawFilePath-1"
+       (True @?= True)
+  ]
+

--- a/test/unit/Databrary/Service/MailTest.hs
+++ b/test/unit/Databrary/Service/MailTest.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Databrary.Service.MailTest
+   ( tests )
+where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Databrary.Service.Mail
+
+tests :: TestTree
+tests = testGroup "Databrary.Service.Mail"
+  [ testCase "wrapText-1"
+       (wrapText 10 "two lines of stuff" @?= "two lines\nof stuff\n")
+  ]
+

--- a/test/unit/Databrary/Service/PasswdTest.hs
+++ b/test/unit/Databrary/Service/PasswdTest.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Databrary.Service.PasswdTest
+   ( tests )
+where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Databrary.Service.Passwd
+
+tests :: TestTree
+tests = testGroup "Databrary.Service.Passwd"
+  [ testCase "passwdCheck-1" (do
+       p <- initPasswd
+       mErr <- passwdCheck "pass" "user" "john" p
+       (mErr @?= Just "it is too short"))
+  ]
+

--- a/test/unit/Databrary/Solr/ServiceTest.hs
+++ b/test/unit/Databrary/Solr/ServiceTest.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Databrary.Solr.ServiceTest
+   ( tests )
+where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Databrary.Solr.Service
+
+tests :: TestTree
+tests = testGroup "Databrary.Solr.Service"
+  [ testCase "confSolr-1"
+       (True @?= True)
+  ]
+

--- a/test/unit/Databrary/Store/ConfigTest.hs
+++ b/test/unit/Databrary/Store/ConfigTest.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Databrary.Store.ConfigTest
+   ( tests )
+where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Databrary.Store.Config
+
+tests :: TestTree
+tests = testGroup "Databrary.Store.Config"
+  [ testCase "pathKey-1"
+      ((pathKey (Path ["k1", "k2"])) @?= "k1.k2")
+  ]
+

--- a/test/unit/DbraryAuthentUnitTest.hs
+++ b/test/unit/DbraryAuthentUnitTest.hs
@@ -1,0 +1,13 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Databrary.Service.PasswdTest
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit" 
+  [ Databrary.Service.PasswdTest.tests
+  ]
+

--- a/test/unit/DbraryEnvUnitTest.hs
+++ b/test/unit/DbraryEnvUnitTest.hs
@@ -1,0 +1,13 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Databrary.Store.ConfigTest
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit" 
+  [ Databrary.Store.ConfigTest.tests
+  ]
+

--- a/test/unit/DbraryMailUnitTest.hs
+++ b/test/unit/DbraryMailUnitTest.hs
@@ -1,0 +1,13 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Databrary.Service.MailTest
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit" 
+  [ Databrary.Service.MailTest.tests
+  ]
+

--- a/test/unit/DbrarySolrUnitTest.hs
+++ b/test/unit/DbrarySolrUnitTest.hs
@@ -1,0 +1,13 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Databrary.Solr.ServiceTest
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit" 
+  [ Databrary.Solr.ServiceTest.tests
+  ]
+

--- a/test/unit/DbraryStoreUnitTest.hs
+++ b/test/unit/DbraryStoreUnitTest.hs
@@ -1,0 +1,13 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Databrary.FilesTest
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit" 
+  [ Databrary.FilesTest.tests
+  ]
+


### PR DESCRIPTION
- test-suites for env, mail, authent, solr, store, rename unit-test to dbrary
- for now include the under test source in the test suite, later use libs