### PR TITLE
Force chunk size will ensure behavior is honored in last chunk

### DIFF
--- a/web/service/upload.coffee
+++ b/web/service/upload.coffee
@@ -8,7 +8,10 @@ app.factory('uploadService', [
     flowOptions: () ->
       target: router.controllers.uploadChunk.route()
       method: 'octet'
-      chunkSize: 4194304
+      # chunkSize: 4194304
+      chunkSize: 2000000
+      # forceChunkSize: false
+      forceChunkSize: true
       simultaneousUploads: 3
       testChunks: false
       chunkRetryInterval: 5000


### PR DESCRIPTION
- chunk size may have been ignored for last chunk, allowing to exceed limits on some servers

In particular, trying to ensure uploads work on staging again.