### PR TITLE
Undo some temporary settings for ngflow chunk size

### DIFF
--- a/Databrary/Controller/Upload.hs
+++ b/Databrary/Controller/Upload.hs
@@ -73,7 +73,7 @@ chunkForm = do
   let z = uploadSize up
   "flowFilename" .:> (deformGuard "Filename mismatch." . (uploadFilename up ==) =<< deform)
   "flowTotalSize" .:> (deformGuard "File size mismatch." . (z ==) =<< fileSizeForm)
-  c <- "flowChunkSize" .:> (deformCheck "Chunk size too small." (400 <=) =<< deform)
+  c <- "flowChunkSize" .:> (deformCheck "Chunk size too small." (1024 <=) =<< deform)
   n <- "flowTotalChunks" .:> (deformCheck "Chunk count mismatch." ((1 >=) . abs . (pred z `div` c -)) =<< deform)
   i <- "flowChunkNumber" .:> (deformCheck "Chunk number out of range." (\i -> 0 <= i && i < n) =<< pred <$> deform)
   let o = c * i

--- a/web/service/upload.coffee
+++ b/web/service/upload.coffee
@@ -8,10 +8,10 @@ app.factory('uploadService', [
     flowOptions: () ->
       target: router.controllers.uploadChunk.route()
       method: 'octet'
-      # chunkSize: 4194304
-      chunkSize: 500
-      # forceChunkSize: false
-      forceChunkSize: true
+      chunkSize: 4194304
+      # chunkSize: 500
+      forceChunkSize: false
+      # forceChunkSize: true
       simultaneousUploads: 3
       testChunks: false
       chunkRetryInterval: 5000


### PR DESCRIPTION
We need the settings lower to get around an unresolved problem with large uploads on staging. Can reverse once debugging is done.