### PR TITLE
Cache solr download to a central location in ghci-databrary startup

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,12 @@ let
   inherit (nixpkgs.haskell.lib) dontCheck overrideCabal doJailbreak;
   ghciDatabrary = writeScriptBin "ghci-databrary" ''
     if [ ! -d "solr-6.6.0" ]; then
-      wget -qO- http://archive.apache.org/dist/lucene/solr/6.6.0/solr-6.6.0.tgz | tar -zxv
+      if [ ! -d "/tmp/solr-6.6.0" ]; then
+        pushd /tmp > /dev/null
+        wget -qO- http://archive.apache.org/dist/lucene/solr/6.6.0/solr-6.6.0.tgz | tar -zxv
+	popd > /dev/null
+      fi
+      cp -R /tmp/solr-6.6.0 .
     fi
     if [ ! -d "node_modules" ]; then
       echo linking node_modules


### PR DESCRIPTION
- to speed up builds on dev servers where the source directory is repeatedly deleted,
 cache solr exe download to a central location for copying after initial download