### PR TITLE
Remove hardcoded

### DIFF
--- a/Databrary/Model/Volume/Types.hs
+++ b/Databrary/Model/Volume/Types.hs
@@ -51,7 +51,7 @@ volumePublicShareFull :: Volume -> Maybe Bool
 volumePublicShareFull Volume{..} =
   case volumePermission of
     PermissionPUBLIC ->
-      if True -- volumeId volumeRow == Id 365 || volumeName volumeRow == "hardcode"
+      if volumeId volumeRow == Id 365 || volumeName volumeRow == "hardcode"
       then Just False
       else Just True
     _ -> Nothing


### PR DESCRIPTION
- used to force all public volumes to be restricted
- now only force on a magic volume (365) or title ("hardcode")