### PR TITLE
Exercise data migrations in all environments

### DIFF
--- a/databrary.nix
+++ b/databrary.nix
@@ -97,5 +97,6 @@ mkDerivation rec {
 
     # should copy schema dir
     # start this now...
+    cp -r schema $data_outputdir
   '';
 }

--- a/databrary.nix
+++ b/databrary.nix
@@ -96,5 +96,6 @@ mkDerivation rec {
     cp -r solr/solr.xml solr/log4j.properties solr/conf $data_outputdir/solr
 
     # should copy schema dir
+    # start this now...
   '';
 }

--- a/initializeDB.sh
+++ b/initializeDB.sh
@@ -5,4 +5,5 @@ dbPath=$dbName
 echo $dbPath
 chmod 700 $dbPath/work
 # load the schema into the db
-cat ./schema/* | gargoyle-psql "$dbPath"
+# subtly relies on cat listing in deterministic, ascending order
+cat ./schema/*.sql | gargoyle-psql "$dbPath"

--- a/schema/20171215-disable-account.sql
+++ b/schema/20171215-disable-account.sql
@@ -1,0 +1,3 @@
+; -- last migration missing trailing semicolon
+update account set password = null where email = 'lisa@databrary.org';
+ 


### PR DESCRIPTION
As an intermediate step towards having named policies, use a bool to differentiate between two possible policies applied only the the public permission level. The bool will only be used by party "Everybody". All other parties will leave this field as null (check constraint to enforce?).