### PR TITLE
Aggressively guard any routes against public restricted access

### DIFF
--- a/Databrary/Controller/CSV.hs
+++ b/Databrary/Controller/CSV.hs
@@ -112,6 +112,7 @@ volumeCSV vol crsl = do
 csvVolume :: ActionRoute (Id Volume)
 csvVolume = action GET (pathId </< "csv") $ \vi -> withAuth $ do
   vol <- getVolume PermissionPUBLIC vi
+  _ <- maybeAction (if volumeIsPublicRestricted vol then Nothing else Just ()) -- block if restricted
   _:r <- lookupVolumeContainersRecords vol
   csv <- volumeCSV vol r
   return $ csvResponse csv (makeFilename (volumeDownloadName vol))

--- a/Databrary/Controller/Record.hs
+++ b/Databrary/Controller/Record.hs
@@ -48,6 +48,8 @@ getRecord p i =
 viewRecord :: ActionRoute (API, Id Record)
 viewRecord = action GET (pathAPI </> pathId) $ \(api, i) -> withAuth $ do
   rec <- getRecord PermissionPUBLIC i
+  let v = recordVolume rec
+  _ <- maybeAction (if volumeIsPublicRestricted v then Nothing else Just ()) -- block if restricted
   return $ case api of
     JSON -> okResponse [] $ JSON.recordEncoding $ recordJSON False rec -- json should consult volume
     HTML -> okResponse [] $ T.pack $ show $ recordId $ recordRow rec -- TODO

--- a/Databrary/Controller/Volume.hs
+++ b/Databrary/Controller/Volume.hs
@@ -13,6 +13,7 @@ module Databrary.Controller.Volume
   , thumbVolume
   , volumeDownloadName
   , volumeJSONQuery
+  , volumeIsPublicRestricted
   ) where
 
 import Control.Applicative ((<|>), optional)

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -147,6 +147,8 @@ zipContainer isOrig =
                      False -> pathMaybe pathId </> pathSlotId </< "zip" </< "false"
   in action GET zipPath $ \(vi, ci) -> withAuth $ do
     c <- getContainer PermissionPUBLIC vi ci True
+    let v = containerVolume c
+    _ <- maybeAction (if volumeIsPublicRestricted v then Nothing else Just ()) -- block if restricted
     c'<- lookupContainerAssets c
     assetSlots <- case isOrig of 
                        True -> do 
@@ -161,6 +163,7 @@ zipContainer isOrig =
 getVolumeInfo :: Id Volume -> ActionM (Volume, IdSet Container, [AssetSlot])
 getVolumeInfo vi = do
   v <- getVolume PermissionPUBLIC vi
+  _ <- maybeAction (if volumeIsPublicRestricted v then Nothing else Just ()) -- block if restricted
   s <- peeks requestIdSet
   -- let isMember = maybe (const False) (\c -> RS.member (containerId $ containerRow $ slotContainer $ c))
   -- non-exhaustive pattern found here ...v , implment in case of Nothing (Keep in mind originalAssets will not have containers, or Volumes)


### PR DESCRIPTION
- to reach a first user accessible implementation, guard most ways to retrieves parts of a volume with not found.