### PR TITLE
Remove extension, reassemble when building original file name for assets

### DIFF
--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -74,7 +74,9 @@ assetSegmentJSONQuery o q = (assetSegmentJSON o <>) <$> JSON.jsonQuery (assetSeg
 
 assetSegmentDownloadName :: AssetSegment -> [T.Text]
 assetSegmentDownloadName a =
-  volumeDownloadName (view a) ++ foldMap slotDownloadName (assetSlot $ segmentAsset a) ++ assetDownloadName True (assetRow $ view a)
+     volumeDownloadName (view a) 
+  ++ foldMap slotDownloadName (assetSlot $ segmentAsset a)
+  ++ assetDownloadName True False (assetRow $ view a)
 
 viewAssetSegment :: Bool -> ActionRoute (API, Maybe (Id Volume), Id Slot, Id Asset)
 viewAssetSegment getOrig = action GET (pathAPI </>>> pathMaybe pathId </>> pathSlotId </> pathId) $ \(api, vi, si, ai) -> withAuth $ do

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Function (on)
 import Data.List (groupBy, partition)
 import Data.Maybe (fromJust, maybeToList)
+import Control.Monad.IO.Class (liftIO)
 import Data.Monoid ((<>))
 import qualified Data.RangeSet.List as RS
 import qualified Data.Text.Encoding as TE
@@ -61,10 +62,12 @@ assetZipEntry isOrig AssetSlot{ slotAsset = a@Asset{ assetRow = ar@AssetRow{ ass
   req <- peek
   -- (t, _) <- assetCreation a
   -- Just (t, s) <- fileInfo f
+  -- liftIO (print ("downloadname", assetDownloadName False True ar))
+  -- liftIO (print ("format", assetFormat ar))
   return blankZipEntry
     { zipEntryName = case isOrig of
-       False -> makeFilename (assetDownloadName True ar) `addFormatExtension` assetFormat ar
-       True -> makeFilename (assetDownloadName False ar) `addFormatExtension` assetFormat ar
+       False -> makeFilename (assetDownloadName True False ar) `addFormatExtension` assetFormat ar
+       True -> makeFilename (assetDownloadName False True ar) `addFormatExtension` assetFormat ar
     , zipEntryTime = Nothing
     , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewAsset (HTML, assetId ar) []
     , zipEntryContent = ZipEntryFile (fromIntegral $ fromJust $ assetSize ar) f

--- a/Databrary/Model/AssetSlot.hs
+++ b/Databrary/Model/AssetSlot.hs
@@ -47,6 +47,7 @@ import Databrary.Model.SQL
 import Databrary.Model.AssetSlot.Types
 import Databrary.Model.AssetSlot.SQL
 import Databrary.Model.Format.Types
+import Databrary.Model.Format (getFormat')
 import Databrary.Model.PermissionUtil (maskRestrictedString)
 
 lookupAssetSlot :: (MonadHasIdentity c m, MonadDB c m) => Id Asset -> m (Maybe AssetSlot)
@@ -76,17 +77,18 @@ lookupSlotAssets (Slot c s) =
 lookupOrigSlotAssets :: (MonadDB c m) => Slot -> m [AssetSlot]
 lookupOrigSlotAssets slot@(Slot c _) = do
   xs <-  dbQuery [pgSQL|
-    SELECT asset.id,asset.release,asset.duration,asset.name,asset.sha1,asset.size 
+    SELECT asset.id,asset.format,asset.release,asset.duration,asset.name,asset.sha1,asset.size 
     FROM slot_asset 
     INNER JOIN transcode ON slot_asset.asset = transcode.asset
     INNER JOIN asset ON transcode.orig = asset.id
     WHERE slot_asset.container = ${containerId $ containerRow c}
     |]
-  return $ flip fmap xs $ \(assetId,release,duration,name,sha1,size) ->
+  return $ flip fmap xs $ \(assetId,formatId,release,duration,name,sha1,size) ->
     -- this format value is only used to differentiate between audio/video or not
     -- so it is okay that it is hardcoded to mp4, under the assumption that everything with an original
     -- was an audio/video file that went through transcoding
-    let format = Format (Id (-800)) "video/mp4" [] "" {-fromJust . getFormatByExtension $ encodeUtf8 $ fromJust name-} 
+    let format = getFormat' formatId
+          -- Format (Id (-800)) "video/mp4" [] "" {-fromJust . getFormatByExtension $ encodeUtf8 $ fromJust name-}
         assetRow = AssetRow (Id assetId) format release duration name sha1 size
     in AssetSlot (Asset assetRow (containerVolume c)) (Just slot)
 

--- a/Databrary/View/Zip.hs
+++ b/Databrary/View/Zip.hs
@@ -176,4 +176,4 @@ htmlVolumeDescription inzip Volume{ volumeRow = VolumeRow{..}, ..} cite fund glo
     H.td $ maybe mempty (H.string . show) $ assetDuration a
     H.td $ maybe mempty (lazyByteStringHtml . BSB.toLazyByteString . BSB.byteStringHex) $ assetSHA1 a
     where
-    fn = last $ BSC.split '-' $ makeFilename (assetDownloadName True a) `addFormatExtension` assetFormat a
+    fn = last $ BSC.split '-' $ makeFilename (assetDownloadName True False a) `addFormatExtension` assetFormat a


### PR DESCRIPTION
- the name of an original asset has the extension inside of the name, so
when building the name for downloading, remove the extension, build a trimmed name,
then add back the extension
- each file name has a limit on size, unsure why, so format needs to be added after
capping the file name size
- also, when reading original asset, use the proper format instead of making a placeholder
format to indicate the file is a audio/video file