### PR TITLE
Aggressively guard any routes against public restricted access - repeat

### DIFF
--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -76,11 +76,16 @@ import Databrary.View.Asset
 import Control.Monad.IO.Class
 
 getAsset :: Permission -> Id Asset -> ActionM AssetSlot
-getAsset p i =
-  checkPermission p =<< maybeAction =<< lookupAssetSlot i
+getAsset p i = do
+  mAssetSlot <- lookupAssetSlot i
+  assetSlot <- maybeAction mAssetSlot
+  _ <- when (p == PermissionPUBLIC)
+         (maybeAction (if volumeIsPublicRestricted ((assetVolume . slotAsset) assetSlot) then Nothing else Just ()))
+  checkPermission p assetSlot
 
 getOrigAsset :: Permission -> Id Asset -> ActionM AssetSlot
 getOrigAsset p i =
+  -- TODO: same as getAsset check
   checkPermission p =<< maybeAction =<< lookupOrigAssetSlot i
 
 assetJSONField :: AssetSlot -> BS.ByteString -> Maybe BS.ByteString -> ActionM (Maybe JSON.Encoding)

--- a/Databrary/Controller/CSV.hs
+++ b/Databrary/Controller/CSV.hs
@@ -112,6 +112,7 @@ volumeCSV vol crsl = do
 csvVolume :: ActionRoute (Id Volume)
 csvVolume = action GET (pathId </< "csv") $ \vi -> withAuth $ do
   vol <- getVolume PermissionPUBLIC vi
+  _ <- maybeAction (if volumeIsPublicRestricted vol then Nothing else Just ()) -- block if restricted
   _:r <- lookupVolumeContainersRecords vol
   csv <- volumeCSV vol r
   return $ csvResponse csv (makeFilename (volumeDownloadName vol))

--- a/Databrary/Controller/Record.hs
+++ b/Databrary/Controller/Record.hs
@@ -48,6 +48,8 @@ getRecord p i =
 viewRecord :: ActionRoute (API, Id Record)
 viewRecord = action GET (pathAPI </> pathId) $ \(api, i) -> withAuth $ do
   rec <- getRecord PermissionPUBLIC i
+  let v = recordVolume rec
+  _ <- maybeAction (if volumeIsPublicRestricted v then Nothing else Just ()) -- block if restricted
   return $ case api of
     JSON -> okResponse [] $ JSON.recordEncoding $ recordJSON False rec -- json should consult volume
     HTML -> okResponse [] $ T.pack $ show $ recordId $ recordRow rec -- TODO

--- a/Databrary/Controller/Volume.hs
+++ b/Databrary/Controller/Volume.hs
@@ -13,6 +13,7 @@ module Databrary.Controller.Volume
   , thumbVolume
   , volumeDownloadName
   , volumeJSONQuery
+  , volumeIsPublicRestricted
   ) where
 
 import Control.Applicative ((<|>), optional)


### PR DESCRIPTION
To reach a first implementation for use on real volumes, guard most ways to retrieves parts of a volume with not found response.
  