### PR TITLE
Ensure existing cracklib directory doesn't cause creating directory t…

### DIFF
--- a/databrary.nix
+++ b/databrary.nix
@@ -97,7 +97,7 @@ mkDerivation rec {
     cd /tmp
     ${cpio}/bin/cpio -idmv < cracklib-dicts-2.9.0-11.el7.x86_64.cpio
     cd -
-    mkdir $data_outputdir/cracklib
+    mkdir -p $data_outputdir/cracklib
     cp -r /tmp/usr/share/cracklib/pw_dict* $data_outputdir/cracklib
 
     mkdir $data_outputdir/solr

--- a/default.nix
+++ b/default.nix
@@ -32,7 +32,7 @@ let
       cd /tmp
       ${cpio}/bin/cpio -idmv < cracklib-dicts-2.9.0-11.el7.x86_64.cpio
       cd -
-      mkdir cracklib
+      mkdir -p cracklib
       cp -r /tmp/usr/share/cracklib/pw_dict* cracklib
     fi
     if [ ! -d "node_modules" ]; then


### PR DESCRIPTION
…o fail

- before this change, cracklib directory was committed, so it will be present in old clones
- this might not be necessary, just extra caution