### PR TITLE
Re-implement download session to restore bounded memory usage

### DIFF
--- a/Databrary/Action/Response.hs
+++ b/Databrary/Action/Response.hs
@@ -47,8 +47,11 @@ instance ResponseData BSL.ByteString where
 instance ResponseData BS.ByteString where
   response s h = responseBuilder s h . BSB.byteString
 
--- instance ResponseData ((BSB.Builder -> IO ()) -> IO ()) where
---   response s h f = responseStream s h (\w _ -> f w)
+instance ResponseData (Source (ResourceT IO) BS.ByteString) where
+  response s h src =
+    responseStream s h
+      (\send flush ->
+         runConduitRes (src .| mapM_C (\bs -> (lift . send . BZB.fromByteString) bs)))
 
 instance ResponseData StreamingBody where
   response = responseStream

--- a/Databrary/Action/Response.hs
+++ b/Databrary/Action/Response.hs
@@ -27,6 +27,8 @@ import Network.Wai (Response, responseBuilder, responseLBS, StreamingBody, respo
 import System.Posix.Types (FileOffset)
 import qualified Text.Blaze.Html as Html
 import qualified Text.Blaze.Html.Renderer.Utf8 as Html
+import Conduit -- TODO: qualify this
+import qualified Blaze.ByteString.Builder as BZB
 
 import qualified Databrary.JSON as JSON
 
@@ -44,6 +46,9 @@ instance ResponseData BSL.ByteString where
 
 instance ResponseData BS.ByteString where
   response s h = responseBuilder s h . BSB.byteString
+
+-- instance ResponseData ((BSB.Builder -> IO ()) -> IO ()) where
+--   response s h f = responseStream s h (\w _ -> f w)
 
 instance ResponseData StreamingBody where
   response = responseStream

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -122,7 +122,6 @@ containerZipEntry2 isOrig nowUtc c l = do
     ( blankZipEntry2
       { CZP.zipEntryName = containerDir
       -- , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewContainer (HTML, (Nothing, containerId $ containerRow c)) [] -- TODO: add back?
-       -- , zipEntryContent = ZipDirectory a
       , CZP.zipEntryTime = nowUtc
       }
     , noZipData )
@@ -132,12 +131,13 @@ containerZipEntry2 isOrig nowUtc c l = do
 blankZipEntry2 :: CZP.ZipEntry
 blankZipEntry2 = CZP.ZipEntry
   { CZP.zipEntryName = ""
-  , CZP.zipEntryTime = LocalTime (fromGregorian 2017 1 2) midnight -- TODO: unix time 0
+  , CZP.zipEntryTime = LocalTime (ModifiedJulianDay 0) midnight -- 0 is 1858 from modified julian days
   , CZP.zipEntrySize = Nothing
   }
 
 noZipData :: CZP.ZipData a
 noZipData = CZP.ZipDataByteString ""
+-----------
 
 volumeDescription :: Bool -> Volume -> (Container, [RecordSlot]) -> IdSet Container -> [AssetSlot] -> ActionM (Html.Html, [[AssetSlot]], [[AssetSlot]])
 volumeDescription inzip v (_, glob) cs al = do
@@ -201,7 +201,8 @@ zipResponse2 n z = do
         $ BSB.string8 "Downloaded by " <> TE.encodeUtf8Builder (partyName $ partyRow u) <> BSB.string8 " <"
             <> actionURL (Just req) viewParty (HTML, TargetParty $ partyId $ partyRow u) []
             <> BSB.char8 '>'
-      zipOpt = CZP.defaultZipOptions { CZP.zipOpt64 = True, CZP.zipOptCompressLevel = 0 }
+      baseZipOpt = CZP.defaultZipOptions { CZP.zipOpt64 = True, CZP.zipOptCompressLevel = 0 }
+      zipOpt = baseZipOpt { CZP.zipOptInfo = CZP.ZipInfo comment }
   return $ okResponse
     [ (hContentType, "application/zip")
     , ("content-disposition", "attachment; filename=" <> quoteHTTP (n <.> "zip"))

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -117,14 +117,14 @@ containerZipEntry2 isOrig c l = do
   -- req <- peek
   a <- mapM (assetZipEntry2 isOrig) l
   -- TODO: throw exception if called with no entries
-  return (
+  return a {- (
     ( blankZipEntry2
       { CZP.zipEntryName = makeFilename (containerDownloadName c) -- TODO: should end in slash
       -- , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewContainer (HTML, (Nothing, containerId $ containerRow c)) [] -- TODO: add back?
        -- , zipEntryContent = ZipDirectory a
       }
     , noZipData )
-    : a)
+    : a) -}
 
 -- TODO: move to store.zip
 blankZipEntry2 :: CZP.ZipEntry

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -117,14 +117,14 @@ containerZipEntry2 isOrig c l = do
   -- req <- peek
   a <- mapM (assetZipEntry2 isOrig) l
   -- TODO: throw exception if called with no entries
-  return a {- (
+  return (
     ( blankZipEntry2
       { CZP.zipEntryName = makeFilename (containerDownloadName c) -- TODO: should end in slash
       -- , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewContainer (HTML, (Nothing, containerId $ containerRow c)) [] -- TODO: add back?
        -- , zipEntryContent = ZipDirectory a
       }
     , noZipData )
-    : a) -}
+    : a)
 
 -- TODO: move to store.zip
 blankZipEntry2 :: CZP.ZipEntry
@@ -204,7 +204,7 @@ zipResponse2 n z = do
     [ (hContentType, "application/zip")
     , ("content-disposition", "attachment; filename=" <> quoteHTTP (n <.> "zip"))
     , (hCacheControl, "max-age=31556926, private")
-    , (hContentLength, BSC.pack $ show $ (0 :: Word64) {- sizeZip z -} + fromIntegral (BS.length comment))
+    -- , (hContentLength, BSC.pack $ show $ (0 :: Word64) {- sizeZip z -} + fromIntegral (BS.length comment))  -- TODO: restore content length
     ] (   yieldMany z
        .| (fmap (const ()) (CZP.zipStream zipOpt))
       :: ConduitM () BS.ByteString (ResourceT IO) ())

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -206,7 +206,7 @@ zipResponse2 n z = do
     [ (hContentType, "application/zip")
     , ("content-disposition", "attachment; filename=" <> quoteHTTP (n <.> "zip"))
     , (hCacheControl, "max-age=31556926, private")
-    -- , (hContentLength, BSC.pack $ show $ (0 :: Word64) {- sizeZip z -} + fromIntegral (BS.length comment))  -- TODO: restore content length
+    -- , (hContentLength, BSC.pack $ show $ (0 :: Word64) {- sizeZip z -} + fromIntegral (BS.length comment))  -- TODO: does content length have to be exact? skip for now
     ] (   yieldMany z
        .| (fmap (const ()) (CZP.zipStream zipOpt))
       :: ConduitM () BS.ByteString (ResourceT IO) ())

--- a/Databrary/Routes.hs
+++ b/Databrary/Routes.hs
@@ -102,6 +102,8 @@ routeMap = routes
   , route viewContainerActivity
   , route $ zipContainer False 
   , route $ zipContainer True 
+  , route $ zipContainerOld False 
+  , route $ zipContainerOld True 
   , route thumbSlot
 
   , route viewFormats

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -95,8 +95,11 @@ Executable databrary
     range-set-list >= 0.1.2.0,
     invertible >= 0.1.1,
     web-inv-route >= 0.1,
-    smtp-mail >= 0.1.4.6
-
+    smtp-mail >= 0.1.4.6,
+    conduit-combinators >= 1.1.1,
+    zip-stream >= 0.1.0.1,
+    blaze-builder >= 0.4.0.2
+            
   default-language: Haskell2010
   default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
 

--- a/databrary.nix
+++ b/databrary.nix
@@ -12,7 +12,7 @@
 , th-lift-instances, time, transformers, transformers-base, unix
 , unordered-containers, utf8-string, vector, wai, wai-extra, warp
 , warp-tls, web-inv-route, xml, zlib, gargoyle, gargoyle-postgresql
-, postgresql-simple
+, postgresql-simple, conduit-combinators, blaze-builder, zip-stream
 , nodePackages, nodejs, openssl, dbName ? "databrary-nix-db", jdk
 , cpio
 }:
@@ -38,7 +38,7 @@ mkDerivation rec {
     time transformers transformers-base unix unordered-containers
     utf8-string vector wai wai-extra warp warp-tls web-inv-route xml
     zlib gargoyle gargoyle-postgresql
-    postgresql-simple
+    postgresql-simple conduit-combinators blaze-builder zip-stream
   ];
   executableSystemDepends = [ cracklib openssl openssl.dev ];
   executablePkgconfigDepends = [


### PR DESCRIPTION
Most likely upgrading from haskell compiler 7.10.3 to 8 introduced a change in behavior that broke an optimization that our homegrown zip generation logic relied upon

Use third party libraries to generate zip files in memory for download session, restoring the same or better memory behavior as old version of code. `zip-stream` appears to be one of the only libraries that offer this functionality. (There is also an in progress implementation of the feature for `zip` here - https://github.com/mrkkrp/zip/issues/20)

https://github.com/databrary/databrary/pull/269/files