### PR TITLE
Attempt two at download session zip, using fork of zip library

### DIFF
--- a/Databrary/Action/Response.hs
+++ b/Databrary/Action/Response.hs
@@ -28,7 +28,7 @@ import System.Posix.Types (FileOffset)
 import qualified Text.Blaze.Html as Html
 import qualified Text.Blaze.Html.Renderer.Utf8 as Html
 import qualified Conduit as CND
-import Conduit (Source, Flush, (.|))
+import Conduit (Source, Flush, (.|), MonadResource)
 import qualified Data.Binary.Builder as DBB
 
 import qualified Databrary.JSON as JSON
@@ -48,11 +48,11 @@ instance ResponseData BSL.ByteString where
 instance ResponseData BS.ByteString where
   response s h = responseBuilder s h . BSB.byteString
 
-instance ResponseData (Source IO BS.ByteString) where
-  response s h src = -- TODO: proper handle cleanup/close
+instance ResponseData (Source (CND.ResourceT IO) BS.ByteString) where
+  response s h src =
     responseStream s h
-      (\send flush ->
-         CND.runConduit (src .| CND.mapM_C (\bs -> (send (DBB.fromByteString bs)))))
+      (\send flush -> do
+         CND.runConduitRes (src .| (CND.mapM_C (\bs -> CND.lift (send (DBB.fromByteString bs))))))
 
 instance ResponseData StreamingBody where
   response = responseStream

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -126,8 +126,8 @@ containerZipEntry2 :: Bool -> Container -> [AssetSlot] -> ActionM (ZIP.ZipArchiv
 containerZipEntry2 isOrig c l = do
   -- req <- peek
   let containerDir = makeFilename (containerDownloadName c) <> "/"
-  -- zipActs <- mapM (assetZipEntry2 isOrig containerDir) l
-  return (pure ()) -- blankZipEntry -- No way to add directory entry to zip with "zip" library
+  zipActs <- mapM (assetZipEntry2 isOrig containerDir) l
+  return (sequence_ zipActs) -- blankZipEntry -- No way to add directory entry to zip with "zip" library
     -- { zipEntryName = makeFilename (containerDownloadName c)
     -- , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewContainer (HTML, (Nothing, containerId $ containerRow c)) []
     -- , zipEntryContent = ZipDirectory a

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -25,6 +25,8 @@ import qualified Codec.Archive.Zip as ZIP
 import qualified System.IO as IO
 import qualified System.Directory as DIR
 import qualified Conduit as CND
+import Path (parseRelFile)
+import Path.IO (resolveFile')
 
 import Databrary.Ops
 import Databrary.Has (view, peek, peeks)
@@ -149,9 +151,10 @@ zipExample = action GET "example" $ \() -> withAuth $ do
   h <- liftIO $ IO.openFile "/tmp/placeholder.zip" IO.ReadWriteMode
   liftIO $ DIR.removeFile "/tmp/placeholder.zip"
   liftIO $ IO.hSetBinaryMode h True
-
+  s <- liftIO $ (parseRelFile "ent1" >>= ZIP.mkEntrySelector)
   liftIO $ ZIP.createBlindArchive h $ do
     ZIP.setArchiveComment "a comment"
+    ZIP.addEntry ZIP.Store "hello" s
   sz <- liftIO $ (IO.hSeek h IO.SeekFromEnd 0 >> IO.hTell h)
   liftIO $ IO.hSeek h IO.AbsoluteSeek 0
   

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -87,7 +87,7 @@ assetZipEntry2 isOrig containerDir AssetSlot{ slotAsset = a@Asset{ assetRow = ar
   Just f <- case isOrig of 
                  True -> getAssetFile $ fromJust origAsset
                  False -> getAssetFile a
-  -- req <- peek
+  req <- peek
   -- (t, _) <- assetCreation a
   -- Just (t, s) <- fileInfo f
   -- liftIO (print ("downloadname", assetDownloadName False True ar))
@@ -99,18 +99,8 @@ assetZipEntry2 isOrig containerDir AssetSlot{ slotAsset = a@Asset{ assetRow = ar
   entrySelector <- liftIO $ (parseRelFile (BSC.unpack entryName) >>= ZIP.mkEntrySelector)
   return
     (do
-       -- TODO: comment
-       -- TODO: size?
-       ZIP.sinkEntry ZIP.Store (CND.sourceFileBS (BSC.unpack f)) entrySelector)
-  {- blankZipEntry
-    { zipEntryName = case isOrig of
-       False -> makeFilename (assetDownloadName True False ar) `addFormatExtension` assetFormat ar
-       True -> makeFilename (assetDownloadName False True ar) `addFormatExtension` assetFormat ar
-    , zipEntryTime = Nothing
-    , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewAsset (HTML, assetId ar) []
-    , zipEntryContent = ZipEntryFile (fromIntegral $ fromJust $ assetSize ar) f
-    }
-  -}
+       ZIP.sinkEntry ZIP.Store (CND.sourceFileBS (BSC.unpack f)) entrySelector
+       ZIP.setEntryComment (TE.decodeUtf8 $ BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewAsset (HTML, assetId ar) []) entrySelector)
   
 containerZipEntry :: Bool -> Container -> [AssetSlot] -> ActionM ZipEntry
 containerZipEntry isOrig c l = do

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -161,7 +161,10 @@ zipExample = action GET "example" $ \() -> withAuth $ do
     , (hCacheControl, "max-age=31556926, private")
     , (hContentLength, BSC.pack $ show $ sz)
     ]
-    (CND.sourceHandle h :: CND.Source IO BS.ByteString)
+    (CND.bracketP
+       (return h)
+       IO.hClose
+       CND.sourceHandle :: CND.Source (CND.ResourceT IO) BS.ByteString)
 
 zipEmpty :: ZipEntry -> Bool
 zipEmpty ZipEntry{ zipEntryContent = ZipDirectory l } = all zipEmpty l

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -3,6 +3,7 @@ module Databrary.Controller.Zip
   ( zipContainer
   , zipVolume
   , viewVolumeDescription
+  , zipExample
   ) where
 
 import qualified Data.ByteString as BS
@@ -20,6 +21,7 @@ import Network.HTTP.Types (hContentType, hCacheControl, hContentLength)
 import System.Posix.FilePath ((<.>))
 import qualified Text.Blaze.Html5 as Html
 import qualified Text.Blaze.Html.Renderer.Utf8 as Html
+import qualified Codec.Archive.Zip as ZIP
 
 import Databrary.Ops
 import Databrary.Has (view, peek, peeks)
@@ -136,6 +138,12 @@ zipResponse n z = do
     , (hCacheControl, "max-age=31556926, private")
     , (hContentLength, BSC.pack $ show $ sizeZip z + fromIntegral (BS.length comment))
     ] (streamZip z comment)
+
+zipExample :: ActionRoute ()
+zipExample = action GET "example" $ \() -> withAuth $ do
+  return $ okResponse
+    [ ]
+    ("abc" :: String)
 
 zipEmpty :: ZipEntry -> Bool
 zipEmpty ZipEntry{ zipEntryContent = ZipDirectory l } = all zipEmpty l

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -174,25 +174,6 @@ volumeZipEntry2 isOrig v top cs csv al = do
        sequence_ zb
        ZIP.addEntry ZIP.Store (BSL.toStrict (Html.renderHtml desc)) descEntrySelector
        maybe (pure ()) (\c -> ZIP.addEntry ZIP.Store (BSL.toStrict (BSB.toLazyByteString c)) spreadEntrySelector) csv)
-    {-
-    blankZipEntry
-    { zipEntryName = makeFilename $ volumeDownloadName v ++ if idSetIsFull cs then [] else ["PARTIAL"]
-    , zipEntryComment = BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewVolume (HTML, volumeId $ volumeRow v) []
-    , zipEntryContent = ZipDirectory
-      $ blankZipEntry
-        { zipEntryName = "description.html"
-        , zipEntryContent = ZipEntryPure $ Html.renderHtml $ desc
-        }
-      : maybe id (\c -> (blankZipEntry
-        { zipEntryName = "spreadsheet.csv"
-        , zipEntryContent = ZipEntryPure $ BSB.toLazyByteString c
-        } :)) csv
-      (if null zb then zt else (zt ++ [blankZipEntry
-        { zipEntryName = "sessions"
-        , zipEntryContent = ZipDirectory zb
-        }]))
-    }
-    -}
   where
   ent prefix [a@AssetSlot{ assetSlot = Nothing }] = assetZipEntry2 isOrig prefix a -- orig asset doesn't matter here as top level assets aren't transcoded, I believe
   ent prefix (AssetSlot{ assetSlot = Just s } : _) = do

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -144,6 +144,7 @@ zipResponse n z = do
     , (hContentLength, BSC.pack $ show $ sizeZip z + fromIntegral (BS.length comment))
     ] (streamZip z comment)
 
+{-
 zipExample :: ActionRoute ()
 zipExample = action GET "example" $ \() -> withAuth $ do
   let n = "abc"
@@ -152,9 +153,19 @@ zipExample = action GET "example" $ \() -> withAuth $ do
   liftIO $ DIR.removeFile "/tmp/placeholder.zip"
   liftIO $ IO.hSetBinaryMode h True
   s <- liftIO $ (parseRelFile "ent1" >>= ZIP.mkEntrySelector)
+  s2 <- liftIO $ (parseRelFile "ent2" >>= ZIP.mkEntrySelector)
+  s3 <- liftIO $ (parseRelFile "ent3" >>= ZIP.mkEntrySelector)
+  s4 <- liftIO $ (parseRelFile "ent4" >>= ZIP.mkEntrySelector)
+  s5 <- liftIO $ (parseRelFile "ent4" >>= ZIP.mkEntrySelector)
+  s6 <- liftIO $ (parseRelFile "ent4" >>= ZIP.mkEntrySelector)
   liftIO $ ZIP.createBlindArchive h $ do
     ZIP.setArchiveComment "a comment"
     ZIP.addEntry ZIP.Store "hello" s
+    ZIP.sinkEntry ZIP.Deflate (CND.sourceFileBS "/tmp/download.mp4") s2 -- no deflate?
+    ZIP.sinkEntry ZIP.Deflate (CND.sourceFileBS "/tmp/download.mp4") s3 -- no deflate?
+    ZIP.sinkEntry ZIP.Deflate (CND.sourceFileBS "/tmp/download.mp4") s4 -- no deflate?
+    ZIP.sinkEntry ZIP.Deflate (CND.sourceFileBS "/tmp/download.mp4") s5 -- no deflate?
+    ZIP.sinkEntry ZIP.Deflate (CND.sourceFileBS "/tmp/download.mp4") s6 -- no deflate?
   sz <- liftIO $ (IO.hSeek h IO.SeekFromEnd 0 >> IO.hTell h)
   liftIO $ IO.hSeek h IO.AbsoluteSeek 0
   
@@ -168,6 +179,7 @@ zipExample = action GET "example" $ \() -> withAuth $ do
        (return h)
        IO.hClose
        CND.sourceHandle :: CND.Source (CND.ResourceT IO) BS.ByteString)
+-}
 
 zipEmpty :: ZipEntry -> Bool
 zipEmpty ZipEntry{ zipEntryContent = ZipDirectory l } = all zipEmpty l

--- a/Databrary/Routes.hs
+++ b/Databrary/Routes.hs
@@ -103,7 +103,6 @@ routeMap = routes
   , route $ zipContainer False 
   , route $ zipContainer True 
   , route thumbSlot
-  , route zipExample --- DELETE ME PLEASE
 
   , route viewFormats
 

--- a/Databrary/Routes.hs
+++ b/Databrary/Routes.hs
@@ -103,6 +103,7 @@ routeMap = routes
   , route $ zipContainer False 
   , route $ zipContainer True 
   , route thumbSlot
+  , route zipExample --- DELETE ME PLEASE
 
   , route viewFormats
 

--- a/Databrary/Routes.hs
+++ b/Databrary/Routes.hs
@@ -87,6 +87,8 @@ routeMap = routes
   , route viewVolumeCreate
   , route createVolume
   , route queryVolumes
+  , route $ zipVolumeOld False 
+  , route $ zipVolumeOld True
   , route $ zipVolume False 
   , route $ zipVolume True 
   , route viewVolumeDescription

--- a/Databrary/Routes.hs
+++ b/Databrary/Routes.hs
@@ -100,6 +100,8 @@ routeMap = routes
   , route postContainer
   , route deleteContainer
   , route viewContainerActivity
+  , route $ zipContainerOld False 
+  , route $ zipContainerOld True 
   , route $ zipContainer False 
   , route $ zipContainer True 
   , route thumbSlot

--- a/Databrary/Store/Zip.hs
+++ b/Databrary/Store/Zip.hs
@@ -9,6 +9,8 @@ module Databrary.Store.Zip
   , fileZipEntry
   ) where
 
+-- TOOD: delete entire module
+
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.RWS.Strict (RWST, execRWST, ask, local, tell)

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -97,8 +97,9 @@ Executable databrary
     web-inv-route >= 0.1,
     smtp-mail >= 0.1.4.6,
     zip >= 0.1.3,
-    conduit-combinators >= 1.1.1
-        
+    conduit-combinators >= 1.1.1,
+    binary >= 0.8.3.0
+            
   default-language: Haskell2010
   default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
 

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -96,8 +96,7 @@ Executable databrary
     invertible >= 0.1.1,
     web-inv-route >= 0.1,
     smtp-mail >= 0.1.4.6,
-    -- TODO: set version
-    zip >= 0,
+    zip >= 0.1.3,
     conduit-combinators >= 1.1.1
         
   default-language: Haskell2010

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -95,8 +95,11 @@ Executable databrary
     range-set-list >= 0.1.2.0,
     invertible >= 0.1.1,
     web-inv-route >= 0.1,
-    smtp-mail >= 0.1.4.6
-
+    smtp-mail >= 0.1.4.6,
+    -- TODO: set version
+    zip >= 0,
+    conduit-combinators >= 1.1.1
+        
   default-language: Haskell2010
   default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
 

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -98,8 +98,10 @@ Executable databrary
     smtp-mail >= 0.1.4.6,
     zip >= 0.1.3,
     conduit-combinators >= 1.1.1,
-    binary >= 0.8.3.0
-            
+    binary >= 0.8.3.0,
+    path >= 0.5.13,
+    path-io >= 1.2.2
+                    
   default-language: Haskell2010
   default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
 

--- a/databrary.nix
+++ b/databrary.nix
@@ -12,7 +12,7 @@
 , th-lift-instances, time, transformers, transformers-base, unix
 , unordered-containers, utf8-string, vector, wai, wai-extra, warp
 , warp-tls, web-inv-route, xml, zlib, gargoyle, gargoyle-postgresql
-, postgresql-simple
+, postgresql-simple, zip, conduit-combinators
 , nodePackages, nodejs, openssl, dbName ? "databrary-nix-db", jdk
 , cpio
 }:
@@ -37,7 +37,7 @@ mkDerivation rec {
     streaming-commons template-haskell text th-lift th-lift-instances
     time transformers transformers-base unix unordered-containers
     utf8-string vector wai wai-extra warp warp-tls web-inv-route xml
-    zlib gargoyle gargoyle-postgresql
+    zlib gargoyle gargoyle-postgresql zip conduit-combinators
     postgresql-simple
   ];
   executableSystemDepends = [ cracklib openssl openssl.dev ];

--- a/databrary.nix
+++ b/databrary.nix
@@ -12,7 +12,7 @@
 , th-lift-instances, time, transformers, transformers-base, unix
 , unordered-containers, utf8-string, vector, wai, wai-extra, warp
 , warp-tls, web-inv-route, xml, zlib, gargoyle, gargoyle-postgresql
-, postgresql-simple, zip, conduit-combinators
+, postgresql-simple, zip, conduit-combinators, binary
 , nodePackages, nodejs, openssl, dbName ? "databrary-nix-db", jdk
 , cpio
 }:
@@ -38,7 +38,7 @@ mkDerivation rec {
     time transformers transformers-base unix unordered-containers
     utf8-string vector wai wai-extra warp warp-tls web-inv-route xml
     zlib gargoyle gargoyle-postgresql zip conduit-combinators
-    postgresql-simple
+    postgresql-simple binary
   ];
   executableSystemDepends = [ cracklib openssl openssl.dev ];
   executablePkgconfigDepends = [

--- a/databrary.nix
+++ b/databrary.nix
@@ -12,7 +12,7 @@
 , th-lift-instances, time, transformers, transformers-base, unix
 , unordered-containers, utf8-string, vector, wai, wai-extra, warp
 , warp-tls, web-inv-route, xml, zlib, gargoyle, gargoyle-postgresql
-, postgresql-simple, zip, conduit-combinators, binary
+, postgresql-simple, zip, conduit-combinators, binary, path, path-io
 , nodePackages, nodejs, openssl, dbName ? "databrary-nix-db", jdk
 , cpio
 }:
@@ -37,7 +37,7 @@ mkDerivation rec {
     streaming-commons template-haskell text th-lift th-lift-instances
     time transformers transformers-base unix unordered-containers
     utf8-string vector wai wai-extra warp warp-tls web-inv-route xml
-    zlib gargoyle gargoyle-postgresql zip conduit-combinators
+    zlib gargoyle gargoyle-postgresql zip conduit-combinators path path-io
     postgresql-simple binary
   ];
   executableSystemDepends = [ cracklib openssl openssl.dev ];

--- a/default.nix
+++ b/default.nix
@@ -87,6 +87,8 @@ let
       postgresql-binary = dontCheck (self.callHackage  "postgresql-binary" "0.10" {});
       # Define postgresql-typed package with explicit version number
       postgresql-typed = dontCheck (self.callHackage  "postgresql-typed" "0.4.5" {});
+      # Define zip with special fork including streaming support; dontCheck to save time
+      zip = dontCheck (self.callPackage ./zip-blind.nix {});
     };
   };
 in { databrary = pkgs.databrary; databrary-dev = pkgs.databrary-dev; }

--- a/zip-blind.nix
+++ b/zip-blind.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, base, bytestring, bzlib-conduit, case-insensitive
+, cereal, conduit, conduit-extra, containers, criterion, digest
+, exceptions, fetchgit, filepath, hspec, mtl, path, path-io, plan-b
+, QuickCheck, resourcet, stdenv, text, time, transformers
+}:
+mkDerivation {
+  pname = "zip";
+  version = "0.1.3";
+  src = fetchgit {
+    url = "http://github.com/robertleegdm/zip.git";
+    sha256 = "1kbkd67rjvnhxp3p18pqbdv50vxr4k5d1mziyf7hhv5nkpv4g32c";
+    rev = "594d57a09f6b957ba0fb54151f49e10a2eba4fdd";
+  };
+  libraryHaskellDepends = [
+    base bytestring bzlib-conduit case-insensitive cereal conduit
+    conduit-extra containers digest exceptions filepath mtl path
+    path-io plan-b resourcet text time transformers
+  ];
+  testHaskellDepends = [
+    base bytestring conduit containers exceptions filepath hspec path
+    path-io QuickCheck text time transformers
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  homepage = "https://github.com/mrkkrp/zip";
+  description = "Operations on zip archives";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
- hoping building zip with ephmeral file handle will allow for computing size accurately to be able to populate content-length in http response and satisfy OS X archiver

attempt 1: https://github.com/databrary/databrary/pull/271
using https://github.com/mrkkrp/zip/pull/22/files