### PR TITLE
Fix Excerpt Thumbnail and Download Access for Partially Shared Volumes - Backend Phase 1

### DIFF
--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -327,6 +327,6 @@ thumbAsset = action GET (pathId </> pathSegment </< "thumb") $ \(ai, seg) -> wit
   let as = assetSegmentInterp 0.25 $ newAssetSegment a seg Nothing
   if formatIsImage (view as)
     && assetBacked (view as)
-    && dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as > PermissionNONE
+    && canReadData getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as
     then peeks $ otherRouteResponse [] downloadAsset (view as, assetSegment as)
     else peeks $ otherRouteResponse [] formatIcon (view as)

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -90,13 +90,12 @@ getAsset getOrig p checkDataPerm i = do
   when checkDataPerm $ do
     liftIO $ -- TODO: delete
       print ("checking data perm", "assetSlot", assetSlot)
-    -- liftIO $ -- TODO: delete
-    --   print ("checking data perm", "seg rlses", getAssetSlotRelease2 assetSlot)
-           -- "vol prm", getAssetSegmentVolumePermission2 assetSlot) 
-    -- liftIO $ -- TODO: delete
-    --  print ("result perm", dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
-    -- void (checkDataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
-    pure ()
+    liftIO $ -- TODO: delete
+      print ("checking data perm", "seg rlses", getAssetSlotRelease2 assetSlot,
+             "vol prm", getAssetSlotVolumePermission2 assetSlot) 
+    liftIO $ -- TODO: delete
+      print ("result perm", dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
+    void (checkDataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
   pure assetSlot
   -- where
     -- excerptAccessible :: [Excerpt] -> Bool

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -79,27 +79,15 @@ getAsset :: Bool -> Permission -> Bool -> Id Asset -> ActionM AssetSlot
 getAsset getOrig p checkDataPerm i = do
   mAssetSlot <- (if getOrig then lookupOrigAssetSlot else lookupAssetSlot) i
   assetSlot <- maybeAction mAssetSlot
-  {-
-  assetExcerpts <- lookupAssetExcerpts assetSlot
-  _ <- when (p == PermissionPUBLIC)
-         (maybeAction
-            (if volumeIsPublicRestricted (getAssetSlotVolume assetSlot) && not (excerptAccessible assetExcerpts)
-             then Nothing
-             else Just ())) -}
   void (checkPermission2 (fst . getAssetSlotVolumePermission2) p assetSlot)
   when checkDataPerm $ do
-    liftIO $ -- TODO: delete
-      print ("checking data perm", "assetSlot", assetSlot)
-    liftIO $ -- TODO: delete
-      print ("checking data perm", "seg rlses", getAssetSlotRelease2 assetSlot,
-             "vol prm", getAssetSlotVolumePermission2 assetSlot) 
-    liftIO $ -- TODO: delete
-      print ("result perm", dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
+    -- TODO: delete
+    liftIO $ print ("checking data perm", "assetSlot", assetSlot)
+    liftIO $ print ("checking data perm", "seg rlses", getAssetSlotRelease2 assetSlot,
+                    "vol prm", getAssetSlotVolumePermission2 assetSlot) 
+    liftIO $ print ("result perm", dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
     void (checkDataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
   pure assetSlot
-  -- where
-    -- excerptAccessible :: [Excerpt] -> Bool
-    -- excerptAccessible exs = (not . null) exs -- is this good enough? how prevent access to unshared part of excerpt
 
 assetJSONField :: AssetSlot -> BS.ByteString -> Maybe BS.ByteString -> ActionM (Maybe JSON.Encoding)
 assetJSONField a "container" _ =

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -86,7 +86,7 @@ getAsset getOrig p checkDataPerm i = do
             (if volumeIsPublicRestricted (getAssetSlotVolume assetSlot) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ())) -}
-  void (checkPermission2 getAssetSlotVolumePermission p assetSlot)
+  void (checkPermission2 (fst . getAssetSlotVolumePermission2) p assetSlot)
   when checkDataPerm $ do
     liftIO $ -- TODO: delete
       print ("checking data perm", "assetSlot", assetSlot)
@@ -335,7 +335,7 @@ downloadOrigAsset = action GET (pathId </> pathSegment </< "downloadOrig") $ \(a
 
 thumbAsset :: ActionRoute (Id Asset, Segment)
 thumbAsset = action GET (pathId </> pathSegment </< "thumb") $ \(ai, seg) -> withAuth $ do
-  a <- getAsset False PermissionPUBLIC True ai
+  a <- getAsset False PermissionPUBLIC False ai
   let as = assetSegmentInterp 0.25 $ newAssetSegment a seg Nothing
   if formatIsImage (view as)
     && assetBacked (view as)

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -85,7 +85,7 @@ getAsset p i = do
             (if volumeIsPublicRestricted ((assetVolume . slotAsset) assetSlot) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ()))
-  checkPermission p assetSlot
+  checkPermission2 (volumePermission . assetVolume . slotAsset) p assetSlot -- TODO: move getter to model
   where
     excerptAccessible :: [Excerpt] -> Bool
     excerptAccessible exs = (not . null) exs -- is this good enough? how prevent access to unshared part of excerpt

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -102,12 +102,6 @@ getAsset getOrig p checkDataPerm i = do
     -- excerptAccessible :: [Excerpt] -> Bool
     -- excerptAccessible exs = (not . null) exs -- is this good enough? how prevent access to unshared part of excerpt
 
-{-
-getOrigAsset :: Permission -> Id Asset -> ActionM AssetSlot
-getOrigAsset p i =
-  checkPermission p =<< maybeAction =<< lookupOrigAssetSlot i
--}
-
 assetJSONField :: AssetSlot -> BS.ByteString -> Maybe BS.ByteString -> ActionM (Maybe JSON.Encoding)
 assetJSONField a "container" _ =
   return $ JSON.recordEncoding . containerJSON False . slotContainer <$> assetSlot a -- containerJSON should consult volume

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -331,6 +331,8 @@ thumbAsset :: ActionRoute (Id Asset, Segment)
 thumbAsset = action GET (pathId </> pathSegment </< "thumb") $ \(ai, seg) -> withAuth $ do
   a <- getAsset PermissionPUBLIC ai
   let as = assetSegmentInterp 0.25 $ newAssetSegment a seg Nothing
-  if formatIsImage (view as) && assetBacked (view as) && dataPermission as > PermissionNONE
+  if formatIsImage (view as)
+    && assetBacked (view as)
+    && dataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as > PermissionNONE
     then peeks $ otherRouteResponse [] downloadAsset (view as, assetSegment as)
     else peeks $ otherRouteResponse [] formatIcon (view as)

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -79,12 +79,16 @@ getAsset :: Permission -> Id Asset -> ActionM AssetSlot
 getAsset p i = do
   mAssetSlot <- lookupAssetSlot i
   assetSlot <- maybeAction mAssetSlot
+  assetExcerpts <- lookupAssetExcerpts assetSlot
   _ <- when (p == PermissionPUBLIC)
          (maybeAction
-            (if volumeIsPublicRestricted ((assetVolume . slotAsset) assetSlot)
+            (if volumeIsPublicRestricted ((assetVolume . slotAsset) assetSlot) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ()))
   checkPermission p assetSlot
+  where
+    excerptAccessible :: [Excerpt] -> Bool
+    excerptAccessible exs = (not . null) exs -- is this good enough? how prevent access to unshared part of excerpt
 
 getOrigAsset :: Permission -> Id Asset -> ActionM AssetSlot
 getOrigAsset p i =

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -86,7 +86,7 @@ getAsset getOrig p checkDataPerm i = do
     liftIO $ print ("checking data perm", "seg rlses", getAssetSlotRelease2 assetSlot,
                     "vol prm", getAssetSlotVolumePermission2 assetSlot) 
     liftIO $ print ("result perm", dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
-    void (checkDataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
+    void (userCanReadData getAssetSlotRelease2 getAssetSlotVolumePermission2 assetSlot)
   pure assetSlot
 
 assetJSONField :: AssetSlot -> BS.ByteString -> Maybe BS.ByteString -> ActionM (Maybe JSON.Encoding)

--- a/Databrary/Controller/Asset.hs
+++ b/Databrary/Controller/Asset.hs
@@ -82,10 +82,10 @@ getAsset p i = do
   assetExcerpts <- lookupAssetExcerpts assetSlot
   _ <- when (p == PermissionPUBLIC)
          (maybeAction
-            (if volumeIsPublicRestricted ((assetVolume . slotAsset) assetSlot) && not (excerptAccessible assetExcerpts)
+            (if volumeIsPublicRestricted (getAssetSlotVolume assetSlot) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ()))
-  checkPermission2 (volumePermission . assetVolume . slotAsset) p assetSlot -- TODO: move getter to model
+  checkPermission2 getAssetSlotVolumePermission p assetSlot -- TODO: move getter to model
   where
     excerptAccessible :: [Excerpt] -> Bool
     excerptAccessible exs = (not . null) exs -- is this good enough? how prevent access to unshared part of excerpt

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -62,8 +62,7 @@ getAssetSegment getOrig p mv s a = do
             (if volumeIsPublicRestricted ((assetVolume . slotAsset . segmentAsset) assetSeg) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ()))
-  checkPermission p assetSeg
-  -- checkPermission p =<< maybeAction . maybe id (\v -> mfilter $ (v ==) . view) mv =<< lookupOrigSlotAssetSegment s a
+  checkPermission2 (volumePermission . assetVolume . slotAsset . segmentAsset) p assetSeg
   where
     -- TODO: fix, repeated from ASSET
     excerptAccessible :: [Excerpt] -> Bool

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -94,7 +94,12 @@ viewAssetSegment getOrig = action GET (pathAPI </>>> pathMaybe pathId </>> pathS
 
 serveAssetSegment :: Bool -> AssetSegment -> ActionM Response
 serveAssetSegment dl as = do
-  _ <- checkDataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as
+  liftIO $ -- TODO: delete
+    print ("checking data perm", "seg rls", getAssetSegmentRelease as, "vol prm", getAssetSegmentVolumePermission as) 
+  liftIO $ -- TODO: delete
+    print ("result perm", dataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as)
+  -- _ <- checkDataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as
+  _ <- checkDataPermission3 getAssetSegmentRelease2 (const (PermissionPUBLIC, PublicRestricted)) as
   sz <- peeks $ readMaybe . BSC.unpack <=< join . listToMaybe . lookupQueryParameters "size"
   when dl $ auditAssetSegmentDownload True as
   store <- maybeAction =<< getAssetFile a

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -62,7 +62,7 @@ getAssetSegment getOrig p checkDataPerm mv s a = do
     liftIO $ print ("checking data perm", "seg rlses", getAssetSegmentRelease2 assetSeg,
                     "vol prm", getAssetSegmentVolumePermission2 assetSeg) 
     liftIO $ print ("result perm", dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
-    void (checkDataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
+    void (userCanReadData getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
   pure assetSeg
 
 assetSegmentJSONField :: AssetSegment -> BS.ByteString -> Maybe BS.ByteString -> ActionM (Maybe JSON.Encoding)

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -59,7 +59,7 @@ getAssetSegment getOrig p mv s a = do
   assetExcerpts <- lookupAssetExcerpts (segmentAsset assetSeg)
   _ <- when (p == PermissionPUBLIC)
          (maybeAction
-            (if volumeIsPublicRestricted ((assetVolume . slotAsset . segmentAsset) assetSeg)
+            (if volumeIsPublicRestricted ((assetVolume . slotAsset . segmentAsset) assetSeg) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ()))
   checkPermission p assetSeg

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -63,7 +63,7 @@ getAssetSegment getOrig p checkDataPerm mv s a = do
             (if volumeIsPublicRestricted (getAssetSegmentVolume assetSeg) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ())) -}
-  _ <- checkPermission2 getAssetSegmentVolumePermission p assetSeg
+  void (checkPermission2 (fst . getAssetSegmentVolumePermission2) p assetSeg)
   when checkDataPerm $ do
     liftIO $ -- TODO: delete
       print ("checking data perm", "as", assetSeg)
@@ -74,8 +74,7 @@ getAssetSegment getOrig p checkDataPerm mv s a = do
       print ("result perm", dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
     void (checkDataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 assetSeg)
   pure assetSeg
-  where
-    -- TODO: fix, repeated from ASSET
+  -- where
     -- excerptAccessible :: [Excerpt] -> Bool
     -- excerptAccessible exs = (not . null) exs -- is this good enough? how prevent access to unshared part of excerpt
 
@@ -140,6 +139,6 @@ thumbAssetSegment getOrig = action GET (pathSlotId </> pathId </< "thumb") $ \(s
   let as' = assetSegmentInterp 0.25 as
   if formatIsImage (view as')
     && assetBacked (view as)
-    && dataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as' > PermissionNONE
+    && dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as' > PermissionNONE
     then peeks $ otherRouteResponse [] downloadAssetSegment (slotId $ view as', assetId $ assetRow $ view as')
     else peeks $ otherRouteResponse [] formatIcon (view as)

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -95,11 +95,13 @@ viewAssetSegment getOrig = action GET (pathAPI </>>> pathMaybe pathId </>> pathS
 serveAssetSegment :: Bool -> AssetSegment -> ActionM Response
 serveAssetSegment dl as = do
   liftIO $ -- TODO: delete
-    print ("checking data perm", "seg rls", getAssetSegmentRelease as, "vol prm", getAssetSegmentVolumePermission as) 
+    print ("checking data perm", "as", as)
   liftIO $ -- TODO: delete
-    print ("result perm", dataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as)
+    print ("checking data perm", "seg rlses", getAssetSegmentRelease2 as, "vol prm", getAssetSegmentVolumePermission2 as) 
+  liftIO $ -- TODO: delete
+    print ("result perm", dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as)
   -- _ <- checkDataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as
-  _ <- checkDataPermission3 getAssetSegmentRelease2 (const (PermissionPUBLIC, PublicRestricted)) as
+  _ <- checkDataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as
   sz <- peeks $ readMaybe . BSC.unpack <=< join . listToMaybe . lookupQueryParameters "size"
   when dl $ auditAssetSegmentDownload True as
   store <- maybeAction =<< getAssetFile a

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -125,6 +125,6 @@ thumbAssetSegment getOrig = action GET (pathSlotId </> pathId </< "thumb") $ \(s
   let as' = assetSegmentInterp 0.25 as
   if formatIsImage (view as')
     && assetBacked (view as)
-    && dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as' > PermissionNONE
+    && canReadData getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as'
     then peeks $ otherRouteResponse [] downloadAssetSegment (slotId $ view as', assetId $ assetRow $ view as')
     else peeks $ otherRouteResponse [] formatIcon (view as)

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -59,10 +59,10 @@ getAssetSegment getOrig p mv s a = do
   assetExcerpts <- lookupAssetExcerpts (segmentAsset assetSeg)
   _ <- when (p == PermissionPUBLIC)
          (maybeAction
-            (if volumeIsPublicRestricted ((assetVolume . slotAsset . segmentAsset) assetSeg) && not (excerptAccessible assetExcerpts)
+            (if volumeIsPublicRestricted (getAssetSegmentVolume assetSeg) && not (excerptAccessible assetExcerpts)
              then Nothing
              else Just ()))
-  checkPermission2 (volumePermission . assetVolume . slotAsset . segmentAsset) p assetSeg
+  checkPermission2 getAssetSegmentVolumePermission p assetSeg
   where
     -- TODO: fix, repeated from ASSET
     excerptAccessible :: [Excerpt] -> Bool

--- a/Databrary/Controller/AssetSegment.hs
+++ b/Databrary/Controller/AssetSegment.hs
@@ -53,8 +53,7 @@ import Databrary.Controller.Format
 -- Boolean flag to toggle the choice of downloading the original asset file. 
 getAssetSegment :: Bool -> Permission -> Bool -> Maybe (Id Volume) -> Id Slot -> Id Asset -> ActionM AssetSegment
 getAssetSegment getOrig p checkDataPerm mv s a = do
-  let lookupSeg = if getOrig then lookupOrigSlotAssetSegment else lookupSlotAssetSegment
-  mAssetSeg <- lookupSeg s a
+  mAssetSeg <- (if getOrig then lookupOrigSlotAssetSegment else lookupSlotAssetSegment) s a
   assetSeg <- maybeAction ((maybe id (\v -> mfilter $ (v ==) . view) mv) mAssetSeg)
   {-
   assetExcerpts <- lookupAssetExcerpts (segmentAsset assetSeg)

--- a/Databrary/Controller/Excerpt.hs
+++ b/Databrary/Controller/Excerpt.hs
@@ -32,7 +32,7 @@ pathExcerpt = pathJSON >/> pathSlotId </> pathId </< "excerpt"
 
 postExcerpt :: ActionRoute (Id Slot, Id Asset)
 postExcerpt = action POST pathExcerpt $ \(si, ai) -> withAuth $ do
-  as <- getAssetSegment False PermissionEDIT Nothing si ai
+  as <- getAssetSegment False PermissionEDIT False Nothing si ai
   e <- runForm Nothing $ do
     csrfForm
     Excerpt as <$> ("release" .:> deformNonEmpty deform)
@@ -54,6 +54,6 @@ postExcerpt = action POST pathExcerpt $ \(si, ai) -> withAuth $ do
 deleteExcerpt :: ActionRoute (Id Slot, Id Asset)
 deleteExcerpt = action DELETE pathExcerpt $ \(si, ai) -> withAuth $ do
   guardVerfHeader
-  as <- getAssetSegment False PermissionEDIT Nothing si ai
+  as <- getAssetSegment False PermissionEDIT False Nothing si ai
   r <- removeExcerpt as
   return $ okResponse [] $ JSON.objectEncoding $ assetSegmentJSON (if r then as{ assetExcerpt = Nothing } else as)

--- a/Databrary/Controller/Excerpt.hs
+++ b/Databrary/Controller/Excerpt.hs
@@ -47,7 +47,7 @@ postExcerpt = action POST pathExcerpt $ \(si, ai) -> withAuth $ do
         }
   when (isNothing $ assetExcerpt as) $
     notice NoticeExcerptVolume
-  when (any (view as <) $ excerptRelease e) $
+  when (any (getAssetSegmentRelease as <) $ excerptRelease e) $
     notice NoticeReleaseExcerpt
   return $ okResponse [] $ JSON.objectEncoding $ assetSegmentJSON (if r then as{ assetExcerpt = Just e } else as)
 

--- a/Databrary/Controller/Excerpt.hs
+++ b/Databrary/Controller/Excerpt.hs
@@ -13,6 +13,7 @@ import Databrary.Has
 import qualified Databrary.JSON as JSON
 import Databrary.Model.Id
 import Databrary.Model.Permission
+import Databrary.Model.Release (EffectiveRelease(..))
 import Databrary.Model.Slot
 import Databrary.Model.Asset
 import Databrary.Model.AssetSegment
@@ -47,7 +48,7 @@ postExcerpt = action POST pathExcerpt $ \(si, ai) -> withAuth $ do
         }
   when (isNothing $ assetExcerpt as) $
     notice NoticeExcerptVolume
-  when (any (getAssetSegmentRelease as <) $ excerptRelease e) $
+  when (any ((effRelPublic . getAssetSegmentRelease2) as <) $ excerptRelease e) $
     notice NoticeReleaseExcerpt
   return $ okResponse [] $ JSON.objectEncoding $ assetSegmentJSON (if r then as{ assetExcerpt = Just e } else as)
 

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -4,6 +4,7 @@ module Databrary.Controller.Permission
   , checkPermission2
   -- , checkDataPermission
   , checkDataPermission2
+  , checkDataPermission3
   , authAccount
   , checkMemberADMIN
   , checkVerfHeader
@@ -17,6 +18,7 @@ import Databrary.Model.Permission
 import Databrary.Model.Release
 import Databrary.Model.Party
 import Databrary.Model.Identity
+import Databrary.Model.Volume (VolumeAccessPolicy)
 import Databrary.HTTP.Request
 import Databrary.Action
 
@@ -47,6 +49,15 @@ checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do
   unless (dataPermission2 getObjRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
     resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
     result resp
+  return obj
+
+checkDataPermission3 :: (a -> Release) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
+checkDataPermission3 getObjRelease getCurrentUserPermLevel obj = do
+  {-
+  unless (dataPermission3 getObjRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
+    resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
+    result resp
+  -}
   return obj
 
 authAccount :: ActionM Account

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -39,6 +39,13 @@ checkDataPermission o = do
   unless (dataPermission o > PermissionNONE) $ result =<< peeks forbiddenResponse
   return o
 
+checkDataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> ActionM a
+checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do
+  unless (dataPermission2 getObjRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
+    resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
+    result resp
+  return obj
+
 authAccount :: ActionM Account
 authAccount = do
   ident <- peek

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -2,7 +2,7 @@
 module Databrary.Controller.Permission
   ( checkPermission
   , checkPermission2
-  , checkDataPermission3
+  , userCanReadData
   , authAccount
   , checkMemberADMIN
   , checkVerfHeader
@@ -31,9 +31,9 @@ checkPermission2 getCurrentUserPermLevel requestingAccessAtPermLevel obj = do
     result resp
   return obj
 
-checkDataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
-checkDataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj = do
-  unless (dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
+userCanReadData :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
+userCanReadData getObjEffectiveRelease getCurrentUserPermLevel obj = do
+  unless (canReadData getObjEffectiveRelease getCurrentUserPermLevel obj) $ do
     resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
     result resp
   return obj

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -2,7 +2,8 @@
 module Databrary.Controller.Permission
   ( checkPermission
   , checkPermission2
-  , checkDataPermission
+  -- , checkDataPermission
+  , checkDataPermission2
   , authAccount
   , checkMemberADMIN
   , checkVerfHeader
@@ -34,10 +35,12 @@ checkPermission2 getCurrentUserPermLevel requestingAccessAtPermLevel obj = do
     result resp
   return obj
 
+{-
 checkDataPermission :: (Has Release a, Has Permission a) => a -> ActionM a
 checkDataPermission o = do
   unless (dataPermission o > PermissionNONE) $ result =<< peeks forbiddenResponse
   return o
+-}
 
 checkDataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> ActionM a
 checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -18,9 +18,12 @@ import Databrary.Model.Identity
 import Databrary.HTTP.Request
 import Databrary.Action
 
+-- logic inside of checkPermission and checkDataPermission should be inside of model layer
 checkPermission :: Has Permission a => Permission -> a -> ActionM a
 checkPermission requiredPermissionLevel objectWithMinimumAllowedPermission = do
-  unless (view objectWithMinimumAllowedPermission >= requiredPermissionLevel) $ result =<< peeks forbiddenResponse
+  unless (view objectWithMinimumAllowedPermission >= requiredPermissionLevel) $ do
+    resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
+    result resp
   return objectWithMinimumAllowedPermission
 
 checkDataPermission :: (Has Release a, Has Permission a) => a -> ActionM a

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -22,7 +22,7 @@ import Databrary.HTTP.Request
 import Databrary.Action
 
 -- logic inside of checkPermission and checkDataPermission should be inside of model layer
-checkPermission :: Has Permission a => Permission -> a -> ActionM a
+checkPermission :: Has Permission a => Permission -> a -> ActionM a  -- TODO: delete this
 checkPermission requiredPermissionLevel objectWithCurrentUserPermLevel =
   checkPermission2 view requiredPermissionLevel objectWithCurrentUserPermLevel
 

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -19,9 +19,9 @@ import Databrary.HTTP.Request
 import Databrary.Action
 
 checkPermission :: Has Permission a => Permission -> a -> ActionM a
-checkPermission p o = do
-  unless (view o >= p) $ result =<< peeks forbiddenResponse
-  return o
+checkPermission requiredPermissionLevel objectWithMinimumAllowedPermission = do
+  unless (view objectWithMinimumAllowedPermission >= requiredPermissionLevel) $ result =<< peeks forbiddenResponse
+  return objectWithMinimumAllowedPermission
 
 checkDataPermission :: (Has Release a, Has Permission a) => a -> ActionM a
 checkDataPermission o = do

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -3,7 +3,7 @@ module Databrary.Controller.Permission
   ( checkPermission
   , checkPermission2
   -- , checkDataPermission
-  , checkDataPermission2
+  -- , checkDataPermission2
   , checkDataPermission3
   , authAccount
   , checkMemberADMIN
@@ -23,11 +23,8 @@ import Databrary.Action
 
 -- logic inside of checkPermission and checkDataPermission should be inside of model layer
 checkPermission :: Has Permission a => Permission -> a -> ActionM a
-checkPermission requiredPermissionLevel objectWithCurrentUserPermLevel = do
-  unless (view objectWithCurrentUserPermLevel >= requiredPermissionLevel) $ do
-    resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
-    result resp
-  return objectWithCurrentUserPermLevel
+checkPermission requiredPermissionLevel objectWithCurrentUserPermLevel =
+  checkPermission2 view requiredPermissionLevel objectWithCurrentUserPermLevel
 
 checkPermission2 :: (a -> Permission) -> Permission -> a -> ActionM a
 checkPermission2 getCurrentUserPermLevel requestingAccessAtPermLevel obj = do
@@ -41,7 +38,6 @@ checkDataPermission :: (Has Release a, Has Permission a) => a -> ActionM a
 checkDataPermission o = do
   unless (dataPermission o > PermissionNONE) $ result =<< peeks forbiddenResponse
   return o
--}
 
 checkDataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> ActionM a
 checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do
@@ -49,6 +45,7 @@ checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do
     resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
     result resp
   return obj
+-}
 
 checkDataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
 checkDataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj = do

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -2,8 +2,6 @@
 module Databrary.Controller.Permission
   ( checkPermission
   , checkPermission2
-  -- , checkDataPermission
-  -- , checkDataPermission2
   , checkDataPermission3
   , authAccount
   , checkMemberADMIN
@@ -32,20 +30,6 @@ checkPermission2 getCurrentUserPermLevel requestingAccessAtPermLevel obj = do
     resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
     result resp
   return obj
-
-{-
-checkDataPermission :: (Has Release a, Has Permission a) => a -> ActionM a
-checkDataPermission o = do
-  unless (dataPermission o > PermissionNONE) $ result =<< peeks forbiddenResponse
-  return o
-
-checkDataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> ActionM a
-checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do
-  unless (dataPermission2 getObjRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
-    resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
-    result resp
-  return obj
--}
 
 checkDataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
 checkDataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj = do

--- a/Databrary/Controller/Permission.hs
+++ b/Databrary/Controller/Permission.hs
@@ -18,7 +18,6 @@ import Databrary.Model.Permission
 import Databrary.Model.Release
 import Databrary.Model.Party
 import Databrary.Model.Identity
-import Databrary.Model.Volume (VolumeAccessPolicy)
 import Databrary.HTTP.Request
 import Databrary.Action
 
@@ -51,13 +50,11 @@ checkDataPermission2 getObjRelease getCurrentUserPermLevel obj = do
     result resp
   return obj
 
-checkDataPermission3 :: (a -> Release) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
-checkDataPermission3 getObjRelease getCurrentUserPermLevel obj = do
-  {-
-  unless (dataPermission3 getObjRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
+checkDataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> ActionM a
+checkDataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj = do
+  unless (dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj > PermissionNONE) $ do
     resp <- peeks (\reqCtxt -> forbiddenResponse reqCtxt)
     result resp
-  -}
   return obj
 
 authAccount :: ActionM Account

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -224,7 +224,7 @@ zipEmpty _ = False
 
 checkAsset :: AssetSlot -> Bool
 checkAsset a = 
-  dataPermission2 getAssetSlotRelease getAssetSlotVolumePermission a > PermissionNONE && assetBacked (view a)
+  dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 a > PermissionNONE && assetBacked (view a)
 
 containerZipEntryCorrectAssetSlots :: Bool -> Container -> ActionM ZipEntry
 containerZipEntryCorrectAssetSlots isOrig c = do

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -223,7 +223,8 @@ zipEmpty ZipEntry{ zipEntryContent = ZipDirectory l } = all zipEmpty l
 zipEmpty _ = False
 
 checkAsset :: AssetSlot -> Bool
-checkAsset a = dataPermission a > PermissionNONE && assetBacked (view a)
+checkAsset a = 
+  dataPermission2 getAssetSlotRelease getAssetSlotVolumePermission a > PermissionNONE && assetBacked (view a)
 
 containerZipEntryCorrectAssetSlots :: Bool -> Container -> ActionM ZipEntry
 containerZipEntryCorrectAssetSlots isOrig c = do

--- a/Databrary/Controller/Zip.hs
+++ b/Databrary/Controller/Zip.hs
@@ -224,7 +224,7 @@ zipEmpty _ = False
 
 checkAsset :: AssetSlot -> Bool
 checkAsset a = 
-  dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 a > PermissionNONE && assetBacked (view a)
+  canReadData getAssetSlotRelease2 getAssetSlotVolumePermission2 a && assetBacked (view a)
 
 containerZipEntryCorrectAssetSlots :: Bool -> Container -> ActionM ZipEntry
 containerZipEntryCorrectAssetSlots isOrig c = do

--- a/Databrary/Model/Asset.hs
+++ b/Databrary/Model/Asset.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings, RecordWildCards, TemplateHaskell, QuasiQuotes, DataKinds #-}
 module Databrary.Model.Asset
   ( module Databrary.Model.Asset.Types
-  , blankAsset
+  -- , blankAsset
   , assetBacked
   , lookupAsset
   , lookupOrigAsset
@@ -37,20 +37,6 @@ import Databrary.Model.Volume
 import Databrary.Model.Format
 import Databrary.Model.Asset.Types
 import Databrary.Model.Asset.SQL
-
-blankAsset :: Volume -> Asset
-blankAsset vol = Asset
-  { assetRow = AssetRow
-    { assetId = error "blankAsset"
-    , assetFormat = unknownFormat
-    , assetRelease = Nothing
-    , assetName = Nothing
-    , assetDuration = Nothing
-    , assetSHA1 = Nothing
-    , assetSize = Nothing
-    }
-  , assetVolume = vol
-  }
 
 assetBacked :: Asset -> Bool
 assetBacked = isJust . assetSHA1 . assetRow

--- a/Databrary/Model/Asset/Types.hs
+++ b/Databrary/Model/Asset/Types.hs
@@ -2,6 +2,7 @@
 module Databrary.Model.Asset.Types
   ( AssetRow(..)
   , Asset(..)
+  , getAssetReleaseMaybe
   ) where
 
 import qualified Data.ByteString as BS
@@ -39,3 +40,5 @@ instance Kinded Asset where
 
 makeHasRec ''AssetRow ['assetId, 'assetFormat, 'assetRelease]
 makeHasRec ''Asset ['assetRow, 'assetVolume]
+getAssetReleaseMaybe :: Asset -> Maybe Release
+getAssetReleaseMaybe = assetRelease . assetRow

--- a/Databrary/Model/Asset/Types.hs
+++ b/Databrary/Model/Asset/Types.hs
@@ -3,6 +3,7 @@ module Databrary.Model.Asset.Types
   ( AssetRow(..)
   , Asset(..)
   , getAssetReleaseMaybe
+  , blankAsset
   ) where
 
 import qualified Data.ByteString as BS
@@ -42,3 +43,17 @@ makeHasRec ''AssetRow ['assetId, 'assetFormat, 'assetRelease]
 makeHasRec ''Asset ['assetRow, 'assetVolume]
 getAssetReleaseMaybe :: Asset -> Maybe Release
 getAssetReleaseMaybe = assetRelease . assetRow
+
+blankAsset :: Volume -> Asset
+blankAsset vol = Asset
+  { assetRow = AssetRow
+    { assetId = error "blankAsset"
+    , assetFormat = unknownFormat
+    , assetRelease = Nothing
+    , assetName = Nothing
+    , assetDuration = Nothing
+    , assetSHA1 = Nothing
+    , assetSize = Nothing
+    }
+  , assetVolume = vol
+  }

--- a/Databrary/Model/AssetSegment.hs
+++ b/Databrary/Model/AssetSegment.hs
@@ -87,7 +87,7 @@ assetSegmentJSON as@AssetSegment{..} =
      "segment" JSON..= assetSegment
   <> "format" JSON..=? (if view segmentAsset == fmt then empty else pure (formatId fmt))
   -- "release" JSON..=? (view as :: Maybe Release)
-  <> "permission" JSON..= dataPermission as
+  <> "permission" JSON..= dataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as
   <> "excerpt" JSON..=? (excerptRelease <$> assetExcerpt)
   where fmt = view as
 

--- a/Databrary/Model/AssetSegment.hs
+++ b/Databrary/Model/AssetSegment.hs
@@ -87,7 +87,7 @@ assetSegmentJSON as@AssetSegment{..} =
      "segment" JSON..= assetSegment
   <> "format" JSON..=? (if view segmentAsset == fmt then empty else pure (formatId fmt))
   -- "release" JSON..=? (view as :: Maybe Release)
-  <> "permission" JSON..= dataPermission2 getAssetSegmentRelease getAssetSegmentVolumePermission as
+  <> "permission" JSON..= dataPermission3 getAssetSegmentRelease2 getAssetSegmentVolumePermission2 as
   <> "excerpt" JSON..=? (excerptRelease <$> assetExcerpt)
   where fmt = view as
 

--- a/Databrary/Model/AssetSegment/SQL.hs
+++ b/Databrary/Model/AssetSegment/SQL.hs
@@ -44,6 +44,7 @@ selectAssetContainerAssetSegment seg = selectJoin 'makeAssetSegment
   , crossJoin
     $ selector ("LATERAL (VALUES (slot_asset.segment * ${" ++ nameRef seg ++ "})) AS asset_segment (segment)")
       $ SelectColumn "asset_segment" "segment"
+  -- asset_segment.segment <@ excerpt.segment == the range of the segment is contained in the range of the excerpt
   , maybeJoinOn "slot_asset.asset = excerpt.asset AND asset_segment.segment <@ excerpt.segment"
     excerptRow
   ]

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -95,7 +95,7 @@ instance Has (Maybe Release) AssetSegment where
   view AssetSegment{ segmentAsset = a, assetExcerpt = Just e } = excerptRelease e <> view a
   view AssetSegment{ segmentAsset = a } = view a
 instance Has Release AssetSegment where
-  view = view . (view :: AssetSegment -> Maybe Release)
+  view = (view :: Maybe Release -> Release) . (view :: AssetSegment -> Maybe Release)
 
 
 data Excerpt = Excerpt

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -128,7 +128,16 @@ testmakeVolume =
     }
 
 {- test cases: (focus on excerpt present or not test to begin with
-
+-- has excerpt
+--    excerpt rel, assetslot rel , pub vol res , priv vol res
+--       x              x            priv          priv
+--     pub              x            pub           pub
+--     share            x            share         priv
+--     priv             x            ....
+--       x            has val        ------ see asset slot tests ---
+--     pub            pub            pub           pub
+-- no excerpt
+--     see asset slot tests
 -}
 testgetAssetSegmentRelease2 :: [(EffectiveRelease, EffectiveRelease)]
 testgetAssetSegmentRelease2 =

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -30,7 +30,6 @@ import Databrary.Model.Container.Types
 import Databrary.Model.Slot.Types
 import Databrary.Model.Format
 import Databrary.Model.Asset.Types
-import Databrary.Model.Asset (blankAsset)
 import Databrary.Model.AssetSlot.Types
 
 data AssetSegment = AssetSegment
@@ -115,8 +114,18 @@ testmakeAssetSlot =
   }
 
 testmakeAsset :: Asset
-testmakeAsset =
-  blankAsset (testmakeVolume)
+testmakeAsset = Asset
+  { assetRow = AssetRow
+    { assetId = error "blankAsset"
+    , assetFormat = unknownFormat
+    , assetRelease = Nothing
+    , assetName = Nothing
+    , assetDuration = Nothing
+    , assetSHA1 = Nothing
+    , assetSize = Nothing
+    }
+  , assetVolume = testmakeVolume
+  }
 
 testmakeVolume :: Volume
 testmakeVolume =

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -104,7 +104,7 @@ getAssetSegmentRelease as =
   fold -- use monoid with foldMap
     (case as of
        AssetSegment{ segmentAsset = a, assetExcerpt = Just e } ->
-            excerptRelease e
+            excerptRelease e  -- Maybe Release monoid takes the first just, if both just, then max of values
          <> getAssetSlotReleaseMaybe a
        AssetSegment{ segmentAsset = a } -> getAssetSlotReleaseMaybe a)
 instance Has (Maybe Release) AssetSegment where

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -11,6 +11,8 @@ module Databrary.Model.AssetSegment.Types
   , Excerpt(..)
   , newExcerpt
   , excerptInSegment
+  -- for testing only
+  , testgetAssetSegmentRelease2
   ) where
 
 import Data.Foldable (fold)
@@ -98,62 +100,95 @@ instance Has (Id Format) AssetSegment where
   view = formatId . view
 
 -- TODO: move to unit test suite
-testmakeAssetSegment :: AssetSegment
-testmakeAssetSegment =
+testmakeAssetSegment :: AssetSlot -> Bool -> Maybe Release -> AssetSegment
+testmakeAssetSegment as hasExcerpt mRel =
   AssetSegment {
-      segmentAsset = testmakeAssetSlot
-    , assetSegment = Segment (Range.Empty)
-    , assetExcerpt = Nothing
+      segmentAsset = as
+    , assetSegment = fullSegment
+    , assetExcerpt = if hasExcerpt then Just (newExcerpt as fullSegment mRel) else Nothing
   }
   
-testmakeAssetSlot :: AssetSlot
-testmakeAssetSlot =
-  AssetSlot {
-      slotAsset = testmakeAsset
-    , assetSlot = Nothing -- Just testMakeSlot
-  }
+testmakeAssetSlot :: Id Volume -> Maybe Release -> Maybe Slot -> AssetSlot
+testmakeAssetSlot vid mRel ms =
+  let
+    asset = blankAsset (testmakeVolume vid)
+    asset2 = asset { assetRow = (assetRow asset) { assetRelease = mRel } }
+  in
+    AssetSlot { slotAsset = asset2 , assetSlot = ms }
 
-testmakeAsset :: Asset
-testmakeAsset = Asset
-  { assetRow = AssetRow
-    { assetId = error "blankAsset"
-    , assetFormat = unknownFormat
-    , assetRelease = Nothing
-    , assetName = Nothing
-    , assetDuration = Nothing
-    , assetSHA1 = Nothing
-    , assetSize = Nothing
+testmakeSlot :: Slot
+testmakeSlot =
+  Slot {
+      slotContainer =
+        Container {
+            containerRow =
+              ContainerRow { containerId = Id 200, containerTop = False, containerName = Nothing, containerDate = Nothing }
+          , containerRelease = Nothing
+          , containerVolume = realVolume
+          }
+    , slotSegment = fullSegment
     }
-  , assetVolume = testmakeVolume
-  }
 
-testmakeVolume :: Volume
-testmakeVolume =
+testmakeVolume :: Id Volume -> Volume
+testmakeVolume vid =
   blankVolume {
     volumeRow =
-      (volumeRow blankVolume) {
-          volumeId = Id 0
-        }
+      (volumeRow blankVolume) { volumeId = vid }
     }
+
+realVolume, databrarySystem :: Volume
+realVolume = testmakeVolume realVolumeId
+databrarySystem = testmakeVolume coreVolumeId
+realVolumeId :: Id Volume
+realVolumeId = Id 100
+
+containerAssetSlot :: Maybe Release -> AssetSlot
+containerAssetSlot mRel =
+  testmakeAssetSlot realVolumeId mRel (Just testmakeSlot)
+
+noExcerptContainerAssetNoRelease :: AssetSegment
+excerptNoReleaseContainerAssetNoRelease :: AssetSegment
+noExcerptContainerAssetNoRelease = testmakeAssetSegment (containerAssetSlot Nothing) False Nothing
+excerptNoReleaseContainerAssetNoRelease = testmakeAssetSegment (containerAssetSlot Nothing) True Nothing
+excerptNoReleaseContainerAssetHasRelease = testmakeAssetSegment (containerAssetSlot (Just ReleasePUBLIC)) True Nothing
+excerptPublicReleaseContainerAssetNoRelease = testmakeAssetSegment (containerAssetSlot Nothing) True (Just ReleasePUBLIC)
+excerptSharedReleaseContainerAssetNoRelease = testmakeAssetSegment (containerAssetSlot Nothing) True (Just ReleaseSHARED)
+excerptPrivateReleaseContainerAssetNoRelease = testmakeAssetSegment (containerAssetSlot Nothing) True (Just ReleasePRIVATE)
+
+assetReleaseForPartialAndFullShared, privateReleaseIgnoreSharing :: EffectiveRelease
+excerptReleaseForPartialAndFullShared :: EffectiveRelease
+excerptReleaseForFullySharedOnly :: EffectiveRelease
+assetReleaseForPartialAndFullShared = EffectiveRelease ReleasePUBLIC ReleasePUBLIC
+privateReleaseIgnoreSharing = EffectiveRelease ReleasePRIVATE ReleasePRIVATE
+excerptReleaseForPartialAndFullShared = EffectiveRelease ReleasePUBLIC ReleasePUBLIC
+excerptReleaseForPartialAndFullShared' = EffectiveRelease ReleaseSHARED ReleaseSHARED
+excerptReleaseForPartialAndFullShared'' = EffectiveRelease ReleasePRIVATE ReleasePRIVATE
+excerptReleaseForFullySharedOnly = EffectiveRelease ReleaseSHARED ReleasePRIVATE
 
 {- test cases: (focus on excerpt present or not test to begin with
 -- has excerpt
 --    excerpt rel, assetslot rel , pub vol res , priv vol res
---       x              x            priv          priv
---     pub              x            pub           pub
---     share            x            share         priv
---     priv             x            ....
---       x            has val        ------ see asset slot tests ---
---     pub            pub            pub           pub
+--       x              x            priv          priv         -- DONE
+--       x            has val (pub)  pub           pub     ------ see asset slot tests --- -- DONE
+--     pub              x            pub           pub  -- DONE
+--     share            x            share         priv??  -- DONE
+--     priv             x            priv          priv  -- DONE
+--     pub            pub            pub           pub 
+--     TODO: what other cases matter?
 -- no excerpt
---     see asset slot tests
+--     see asset slot tests -- DONE
 -}
+
 testgetAssetSegmentRelease2 :: [(EffectiveRelease, EffectiveRelease)]
 testgetAssetSegmentRelease2 =
-  [ (getAssetSegmentRelease2 (testmakeAssetSegment), EffectiveRelease ReleasePRIVATE ReleasePRIVATE)
+  [ (getAssetSegmentRelease2 noExcerptContainerAssetNoRelease, privateReleaseIgnoreSharing)
+  , (getAssetSegmentRelease2 excerptNoReleaseContainerAssetNoRelease, privateReleaseIgnoreSharing)
+  , (getAssetSegmentRelease2 excerptNoReleaseContainerAssetHasRelease, assetReleaseForPartialAndFullShared) -- wrong?
+  , (getAssetSegmentRelease2 excerptPublicReleaseContainerAssetNoRelease, excerptReleaseForPartialAndFullShared)
+  , (getAssetSegmentRelease2 excerptSharedReleaseContainerAssetNoRelease, excerptReleaseForPartialAndFullShared') -- wrong?
+  , (getAssetSegmentRelease2 excerptPrivateReleaseContainerAssetNoRelease, excerptReleaseForPartialAndFullShared'')
   ]
 -- END TODO
-
  
   -- when the assetslot has lower permissions than the excerpt, then use the excerpt's permissions
   -- when no excerpt is present, then assume no access

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -1,5 +1,6 @@
 module Databrary.Model.AssetSegment.Types
   ( AssetSegment(..)
+  , getAssetSegmentRelease
   , getAssetSegmentVolumePermission
   , getAssetSegmentVolume
   , newAssetSegment
@@ -12,6 +13,7 @@ module Databrary.Model.AssetSegment.Types
   , excerptInSegment
   ) where
 
+import Data.Foldable (fold)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import qualified Database.PostgreSQL.Typed.Range as Range
@@ -97,6 +99,12 @@ instance Has Format AssetSegment where
 instance Has (Id Format) AssetSegment where
   view = formatId . view
 
+getAssetSegmentRelease :: AssetSegment -> Release
+getAssetSegmentRelease as =
+  fold -- use monoid with foldMap
+    (case as of
+       AssetSegment{ segmentAsset = a, assetExcerpt = Just e } -> excerptRelease e <> view a
+       AssetSegment{ segmentAsset = a } -> view a)
 instance Has (Maybe Release) AssetSegment where
   view AssetSegment{ segmentAsset = a, assetExcerpt = Just e } = excerptRelease e <> view a
   view AssetSegment{ segmentAsset = a } = view a

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -2,7 +2,7 @@ module Databrary.Model.AssetSegment.Types
   ( AssetSegment(..)
   , getAssetSegmentRelease
   , getAssetSegmentRelease2
-  , getAssetSegmentVolumePermission
+--  , getAssetSegmentVolumePermission
   , getAssetSegmentVolumePermission2
   , getAssetSegmentVolume
   , newAssetSegment
@@ -76,12 +76,12 @@ instance Has Volume AssetSegment where
   view = view . segmentAsset
 instance Has (Id Volume) AssetSegment where
   view = view . segmentAsset
-getAssetSegmentVolumePermission :: AssetSegment -> Permission  -- TODO: DELETE THIS
-getAssetSegmentVolumePermission = getAssetSlotVolumePermission . segmentAsset
+-- getAssetSegmentVolumePermission :: AssetSegment -> Permission  -- TODO: DELETE THIS
+-- getAssetSegmentVolumePermission = getAssetSlotVolumePermission . segmentAsset
 getAssetSegmentVolumePermission2 :: AssetSegment -> (Permission, VolumeAccessPolicy)
 getAssetSegmentVolumePermission2 = getAssetSlotVolumePermission2 . segmentAsset
-instance Has Permission AssetSegment where
-  view = view . segmentAsset
+-- instance Has Permission AssetSegment where
+--  view = view . segmentAsset
 
 instance Has Slot AssetSegment where
   view AssetSegment{ segmentAsset = AssetSlot{ assetSlot = Just s }, assetSegment = seg } = s{ slotSegment = seg }
@@ -135,12 +135,13 @@ getAssetSegmentRelease as =
             excerptRelease e  -- Maybe Release monoid takes the first just, if both just, then max of values
          <> getAssetSlotReleaseMaybe a
        AssetSegment{ segmentAsset = a } -> getAssetSlotReleaseMaybe a)
+{-
 instance Has (Maybe Release) AssetSegment where
   view AssetSegment{ segmentAsset = a, assetExcerpt = Just e } = excerptRelease e <> view a
   view AssetSegment{ segmentAsset = a } = view a
 instance Has Release AssetSegment where
   view = (view :: Maybe Release -> Release) . (view :: AssetSegment -> Maybe Release)
-
+-}
 
 data Excerpt = Excerpt
   { excerptAsset :: !AssetSegment

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -1,6 +1,6 @@
 module Databrary.Model.AssetSegment.Types
   ( AssetSegment(..)
-  , getAssetSegmentRelease
+--  , getAssetSegmentRelease
   , getAssetSegmentRelease2
 --  , getAssetSegmentVolumePermission
   , getAssetSegmentVolumePermission2
@@ -115,18 +115,15 @@ getAssetSegmentRelease2 as =
         rel = 
            fold (
                 excerptRelease e  -- Maybe Release monoid takes the first just, if both just, then max of values
-             <> getAssetSlotReleaseMaybe a)
+             <> getAssetSlotReleaseMaybe a) -- TODO: should I expose the guts of getAssetSlotRelease2?
       in 
         EffectiveRelease {
           effRelPublic = rel
         , effRelPrivate = rel
         }
     AssetSegment{ segmentAsset = a } ->
-      EffectiveRelease {
-        effRelPublic = fold (getAssetSlotReleaseMaybe a)
-      , effRelPrivate = ReleasePRIVATE -- (getAssetSlotReleaseMaybe a)
-      }
-  
+      getAssetSlotRelease2 a
+{-  
 getAssetSegmentRelease :: AssetSegment -> Release
 getAssetSegmentRelease as =
   fold -- use monoid with foldMap, mempty = Private
@@ -135,6 +132,7 @@ getAssetSegmentRelease as =
             excerptRelease e  -- Maybe Release monoid takes the first just, if both just, then max of values
          <> getAssetSlotReleaseMaybe a
        AssetSegment{ segmentAsset = a } -> getAssetSlotReleaseMaybe a)
+-}
 {-
 instance Has (Maybe Release) AssetSegment where
   view AssetSegment{ segmentAsset = a, assetExcerpt = Just e } = excerptRelease e <> view a

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -1,5 +1,7 @@
 module Databrary.Model.AssetSegment.Types
   ( AssetSegment(..)
+  , getAssetSegmentVolumePermission
+  , getAssetSegmentVolume
   , newAssetSegment
   , assetFullSegment
   , assetSlotSegment
@@ -64,10 +66,14 @@ instance Has Asset AssetSegment where
   view = view . segmentAsset
 instance Has (Id Asset) AssetSegment where
   view = view . segmentAsset
+getAssetSegmentVolume :: AssetSegment -> Volume
+getAssetSegmentVolume = getAssetSlotVolume . segmentAsset
 instance Has Volume AssetSegment where
   view = view . segmentAsset
 instance Has (Id Volume) AssetSegment where
   view = view . segmentAsset
+getAssetSegmentVolumePermission :: AssetSegment -> Permission
+getAssetSegmentVolumePermission = getAssetSlotVolumePermission . segmentAsset
 instance Has Permission AssetSegment where
   view = view . segmentAsset
 

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -1,6 +1,7 @@
 module Databrary.Model.AssetSegment.Types
   ( AssetSegment(..)
   , getAssetSegmentRelease
+  , getAssetSegmentRelease2
   , getAssetSegmentVolumePermission
   , getAssetSegmentVolume
   , newAssetSegment
@@ -98,6 +99,9 @@ instance Has Format AssetSegment where
     where fmt = view a
 instance Has (Id Format) AssetSegment where
   view = formatId . view
+
+getAssetSegmentRelease2 :: AssetSegment -> Release
+getAssetSegmentRelease2 as = undefined
 
 getAssetSegmentRelease :: AssetSegment -> Release
 getAssetSegmentRelease as =

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -103,8 +103,10 @@ getAssetSegmentRelease :: AssetSegment -> Release
 getAssetSegmentRelease as =
   fold -- use monoid with foldMap
     (case as of
-       AssetSegment{ segmentAsset = a, assetExcerpt = Just e } -> excerptRelease e <> view a
-       AssetSegment{ segmentAsset = a } -> view a)
+       AssetSegment{ segmentAsset = a, assetExcerpt = Just e } ->
+            excerptRelease e
+         <> getAssetSlotReleaseMaybe a
+       AssetSegment{ segmentAsset = a } -> getAssetSlotReleaseMaybe a)
 instance Has (Maybe Release) AssetSegment where
   view AssetSegment{ segmentAsset = a, assetExcerpt = Just e } = excerptRelease e <> view a
   view AssetSegment{ segmentAsset = a } = view a

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -1,8 +1,6 @@
 module Databrary.Model.AssetSegment.Types
   ( AssetSegment(..)
---  , getAssetSegmentRelease
   , getAssetSegmentRelease2
---  , getAssetSegmentVolumePermission
   , getAssetSegmentVolumePermission2
   , getAssetSegmentVolume
   , newAssetSegment
@@ -76,12 +74,8 @@ instance Has Volume AssetSegment where
   view = view . segmentAsset
 instance Has (Id Volume) AssetSegment where
   view = view . segmentAsset
--- getAssetSegmentVolumePermission :: AssetSegment -> Permission  -- TODO: DELETE THIS
--- getAssetSegmentVolumePermission = getAssetSlotVolumePermission . segmentAsset
 getAssetSegmentVolumePermission2 :: AssetSegment -> (Permission, VolumeAccessPolicy)
 getAssetSegmentVolumePermission2 = getAssetSlotVolumePermission2 . segmentAsset
--- instance Has Permission AssetSegment where
---  view = view . segmentAsset
 
 instance Has Slot AssetSegment where
   view AssetSegment{ segmentAsset = AssetSlot{ assetSlot = Just s }, assetSegment = seg } = s{ slotSegment = seg }
@@ -123,23 +117,6 @@ getAssetSegmentRelease2 as =
         }
     AssetSegment{ segmentAsset = a } ->
       getAssetSlotRelease2 a
-{-  
-getAssetSegmentRelease :: AssetSegment -> Release
-getAssetSegmentRelease as =
-  fold -- use monoid with foldMap, mempty = Private
-    (case as of
-       AssetSegment{ segmentAsset = a, assetExcerpt = Just e } ->
-            excerptRelease e  -- Maybe Release monoid takes the first just, if both just, then max of values
-         <> getAssetSlotReleaseMaybe a
-       AssetSegment{ segmentAsset = a } -> getAssetSlotReleaseMaybe a)
--}
-{-
-instance Has (Maybe Release) AssetSegment where
-  view AssetSegment{ segmentAsset = a, assetExcerpt = Just e } = excerptRelease e <> view a
-  view AssetSegment{ segmentAsset = a } = view a
-instance Has Release AssetSegment where
-  view = (view :: Maybe Release -> Release) . (view :: AssetSegment -> Maybe Release)
--}
 
 data Excerpt = Excerpt
   { excerptAsset :: !AssetSegment

--- a/Databrary/Model/AssetSegment/Types.hs
+++ b/Databrary/Model/AssetSegment/Types.hs
@@ -30,6 +30,7 @@ import Databrary.Model.Container.Types
 import Databrary.Model.Slot.Types
 import Databrary.Model.Format
 import Databrary.Model.Asset.Types
+import Databrary.Model.Asset (blankAsset)
 import Databrary.Model.AssetSlot.Types
 
 data AssetSegment = AssetSegment
@@ -97,6 +98,43 @@ instance Has Format AssetSegment where
 instance Has (Id Format) AssetSegment where
   view = formatId . view
 
+-- TODO: move to unit test suite
+testmakeAssetSegment :: AssetSegment
+testmakeAssetSegment =
+  AssetSegment {
+      segmentAsset = testmakeAssetSlot
+    , assetSegment = Segment (Range.Empty)
+    , assetExcerpt = Nothing
+  }
+  
+testmakeAssetSlot :: AssetSlot
+testmakeAssetSlot =
+  AssetSlot {
+      slotAsset = testmakeAsset
+    , assetSlot = Nothing -- Just testMakeSlot
+  }
+
+testmakeAsset :: Asset
+testmakeAsset =
+  blankAsset (testmakeVolume)
+
+testmakeVolume :: Volume
+testmakeVolume =
+  blankVolume {
+    volumeRow =
+      (volumeRow blankVolume) {
+          volumeId = Id 0
+        }
+    }
+
+{- test cases: (focus on excerpt present or not test to begin with
+
+-}
+testgetAssetSegmentRelease2 :: [(EffectiveRelease, EffectiveRelease)]
+testgetAssetSegmentRelease2 =
+  [ (getAssetSegmentRelease2 (testmakeAssetSegment), EffectiveRelease ReleasePRIVATE ReleasePRIVATE)
+  ]
+-- END TODO
 
  
   -- when the assetslot has lower permissions than the excerpt, then use the excerpt's permissions

--- a/Databrary/Model/AssetSlot.hs
+++ b/Databrary/Model/AssetSlot.hs
@@ -153,7 +153,7 @@ assetSlotName :: AssetSlot -> Maybe T.Text
 assetSlotName a =
   guard
     (any (containerTop . containerRow . slotContainer) (assetSlot a)
-     || dataPermission2 getAssetSlotRelease getAssetSlotVolumePermission a > PermissionNONE)
+     || dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 a > PermissionNONE)
   >> assetName (assetRow $ slotAsset a)
 
 assetSlotJSON :: JSON.ToObject o => Bool -> AssetSlot -> JSON.Record (Id Asset) o
@@ -164,7 +164,7 @@ assetSlotJSON publicRestricted as@AssetSlot{..} = assetJSON publicRestricted slo
   <> "permission" JSON..= p
   <> "size" JSON..=? (z <? p > PermissionNONE && any (0 <=) z)
   where
-  p = dataPermission2 getAssetSlotRelease getAssetSlotVolumePermission as
+  p = dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 as
   z = assetSize $ assetRow slotAsset
 
 {-

--- a/Databrary/Model/AssetSlot.hs
+++ b/Databrary/Model/AssetSlot.hs
@@ -153,7 +153,7 @@ assetSlotName :: AssetSlot -> Maybe T.Text
 assetSlotName a =
   guard
     (any (containerTop . containerRow . slotContainer) (assetSlot a)
-     || dataPermission3 getAssetSlotRelease2 getAssetSlotVolumePermission2 a > PermissionNONE)
+     || canReadData getAssetSlotRelease2 getAssetSlotVolumePermission2 a)
   >> assetName (assetRow $ slotAsset a)
 
 assetSlotJSON :: JSON.ToObject o => Bool -> AssetSlot -> JSON.Record (Id Asset) o

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -7,6 +7,7 @@ module Databrary.Model.AssetSlot.Types
   , getAssetSlotVolume
   , getAssetSlotVolumePermission
   , getAssetSlotRelease
+  , getAssetSlotReleaseMaybe
   ) where
 
 import Control.Applicative ((<|>))
@@ -75,13 +76,15 @@ instance Has Segment AssetSlot where
 
 getAssetSlotRelease :: AssetSlot -> Release
 getAssetSlotRelease as =
-  fold
+  fold (getAssetSlotReleaseMaybe as)
+getAssetSlotReleaseMaybe :: AssetSlot -> Maybe Release
+getAssetSlotReleaseMaybe as =
     (case as of
        AssetSlot a (Just s) ->
-         view a <|> view s
+         getAssetReleaseMaybe a <|> getSlotReleaseMaybe s
        AssetSlot a Nothing ->
          if volumeId (volumeRow $ assetVolume a) == Id 0
-         then view a
+         then getAssetReleaseMaybe a
          else Nothing) -- "deleted" assets are always unreleased (private?), not view a
 instance Has (Maybe Release) AssetSlot where
   view (AssetSlot a (Just s)) = view a <|> view s

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -91,6 +91,7 @@ getAssetSlotReleaseMaybe as =
          if volumeId (volumeRow $ assetVolume a) == Id 0
          then getAssetReleaseMaybe a
          else Nothing) -- "deleted" assets are always unreleased (private?), not view a
+{-
 instance Has (Maybe Release) AssetSlot where
   view (AssetSlot a (Just s)) = view a <|> view s
   view (AssetSlot a Nothing)
@@ -98,3 +99,4 @@ instance Has (Maybe Release) AssetSlot where
     | otherwise = Nothing -- "deleted" assets are always unreleased (private?), not view a
 instance Has Release AssetSlot where
   view = view . (view :: AssetSlot -> Maybe Release)
+-}

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -5,7 +5,7 @@ module Databrary.Model.AssetSlot.Types
   , assetSlotId
   , assetNoSlot
   , getAssetSlotVolume
-  , getAssetSlotVolumePermission
+  -- , getAssetSlotVolumePermission
   , getAssetSlotVolumePermission2
   , getAssetSlotRelease
   , getAssetSlotReleaseMaybe
@@ -60,14 +60,8 @@ getAssetSlotVolume :: AssetSlot -> Volume
 getAssetSlotVolume = assetVolume . slotAsset
 instance Has (Id Volume) AssetSlot where
   view = view . slotAsset
-getAssetSlotVolumePermission :: AssetSlot -> Permission -- TODO: DELETE THIS
-getAssetSlotVolumePermission = volumePermission . getAssetSlotVolume
 getAssetSlotVolumePermission2 :: AssetSlot -> (Permission, VolumeAccessPolicy)
 getAssetSlotVolumePermission2 = volumePermissionPolicy . getAssetSlotVolume
-{-
-instance Has Permission AssetSlot where
-  view = view . slotAsset
--}
 
 instance Has (Maybe Slot) AssetSlot where
   view = assetSlot

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -6,9 +6,11 @@ module Databrary.Model.AssetSlot.Types
   , assetNoSlot
   , getAssetSlotVolume
   , getAssetSlotVolumePermission
+  , getAssetSlotRelease
   ) where
 
 import Control.Applicative ((<|>))
+import Data.Foldable (fold)
 
 import Databrary.Has (Has(..))
 import Databrary.Model.Id.Types
@@ -71,6 +73,16 @@ instance Has (Maybe Segment) AssetSlot where
 instance Has Segment AssetSlot where
   view = maybe fullSegment slotSegment . assetSlot
 
+getAssetSlotRelease :: AssetSlot -> Release
+getAssetSlotRelease as =
+  fold
+    (case as of
+       AssetSlot a (Just s) ->
+         view a <|> view s
+       AssetSlot a Nothing ->
+         if volumeId (volumeRow $ assetVolume a) == Id 0
+         then view a
+         else Nothing) -- "deleted" assets are always unreleased (private?), not view a
 instance Has (Maybe Release) AssetSlot where
   view (AssetSlot a (Just s)) = view a <|> view s
   view (AssetSlot a Nothing)

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -63,8 +63,10 @@ getAssetSlotVolumePermission :: AssetSlot -> Permission -- TODO: DELETE THIS
 getAssetSlotVolumePermission = volumePermission . getAssetSlotVolume
 getAssetSlotVolumePermission2 :: AssetSlot -> (Permission, VolumeAccessPolicy)
 getAssetSlotVolumePermission2 = volumePermissionPolicy . getAssetSlotVolume
+{-
 instance Has Permission AssetSlot where
   view = view . slotAsset
+-}
 
 instance Has (Maybe Slot) AssetSlot where
   view = assetSlot

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -6,6 +6,7 @@ module Databrary.Model.AssetSlot.Types
   , assetNoSlot
   , getAssetSlotVolume
   , getAssetSlotVolumePermission
+  , getAssetSlotVolumePermission2
   , getAssetSlotRelease
   , getAssetSlotReleaseMaybe
   ) where
@@ -58,8 +59,10 @@ getAssetSlotVolume :: AssetSlot -> Volume
 getAssetSlotVolume = assetVolume . slotAsset
 instance Has (Id Volume) AssetSlot where
   view = view . slotAsset
-getAssetSlotVolumePermission :: AssetSlot -> Permission
+getAssetSlotVolumePermission :: AssetSlot -> Permission -- TODO: DELETE THIS
 getAssetSlotVolumePermission = volumePermission . getAssetSlotVolume
+getAssetSlotVolumePermission2 :: AssetSlot -> (Permission, VolumeAccessPolicy)
+getAssetSlotVolumePermission2 = volumePermissionPolicy . getAssetSlotVolume
 instance Has Permission AssetSlot where
   view = view . slotAsset
 

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -77,29 +77,32 @@ instance Has Segment AssetSlot where
   view = maybe fullSegment slotSegment . assetSlot
 
 -- TODO: move to unit test suite
-testmakeAssetSlot :: AssetSlot
-testmakeAssetSlot =
-  AssetSlot {
-      slotAsset = testmakeAsset
-    , assetSlot = Nothing -- Just testMakeSlot
-  }
+testmakeAssetSlot :: Asset -> Maybe Slot -> AssetSlot
+testmakeAssetSlot a ms = AssetSlot { slotAsset = a , assetSlot = ms }
 
-testmakeAsset :: Asset
-testmakeAsset = Asset
-  blankAsset (testmakeVolume)
+testmakeAsset :: Volume -> Asset
+testmakeAsset vol =
+  blankAsset vol
 
-testmakeVolume :: Volume
-testmakeVolume =
+testmakeVolume :: Id Volume -> Volume
+testmakeVolume vid =
   blankVolume {
     volumeRow =
       (volumeRow blankVolume) {
-          volumeId = coreVolumeId
+          volumeId = vid
         }
     }
+
+realVolume, databrarySystem :: Volume
+realVolume = testmakeVolume (Id 100)
+databrarySystem = testmakeVolume coreVolumeId
 
 -- test cases:
 -- no slot  -- not part of a session (any longer)
 --    volume id > 0  (if asset is tied to a volume, then it was deleted, so its release is always private)
+containerDeletedPointerToFormerVolume :: AssetSlot
+containerDeletedPointerToFormerVolume =
+  testmakeAssetSlot (testmakeAsset realVolume) Nothing
 --    volume id == 0 ? (mean general asset, not attached to a real volume such as an avatar??)
 --       asset has no release
 --       asset has release with value ....
@@ -111,7 +114,7 @@ testmakeVolume =
 
 testgetAssetSlotRelease2 :: [(EffectiveRelease, EffectiveRelease)]
 testgetAssetSlotRelease2 =
-  [ (getAssetSlotRelease2 (testmakeAssetSlot), EffectiveRelease ReleasePRIVATE ReleasePRIVATE)
+  [ (getAssetSlotRelease2 containerDeletedPointerToFormerVolume, EffectiveRelease ReleasePRIVATE ReleasePRIVATE)
   ]
 
 -- END TODO

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -26,7 +26,7 @@ import Databrary.Model.Container.Types
 import Databrary.Model.Format.Types
 import Databrary.Model.Asset.Types
 import Databrary.Model.Slot.Types
-import Databrary.Model.Asset (blankAsset)
+-- import Databrary.Model.Asset (blankAsset)
 
 data AssetSlotId = AssetSlotId
   { slotAssetId :: !(Id Asset)
@@ -85,8 +85,18 @@ testmakeAssetSlot =
   }
 
 testmakeAsset :: Asset
-testmakeAsset =
-  blankAsset (testmakeVolume)
+testmakeAsset = Asset
+  { assetRow = AssetRow
+    { assetId = error "blankAsset"
+    , assetFormat = unknownFormat
+    , assetRelease = Nothing
+    , assetName = Nothing
+    , assetDuration = Nothing
+    , assetSHA1 = Nothing
+    , assetSize = Nothing
+    }
+  , assetVolume = testmakeVolume
+  }
 
 testmakeVolume :: Volume
 testmakeVolume =

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -80,7 +80,7 @@ instance Has (Maybe Segment) AssetSlot where
 instance Has Segment AssetSlot where
   view = maybe fullSegment slotSegment . assetSlot
 
-getAssetSlotRelease :: AssetSlot -> Release
+getAssetSlotRelease :: AssetSlot -> Release  -- TODO: Delete this and fix usages
 getAssetSlotRelease as =
   fold (getAssetSlotReleaseMaybe as)
 getAssetSlotReleaseMaybe :: AssetSlot -> Maybe Release
@@ -96,15 +96,7 @@ getAssetSlotReleaseMaybe as =
 getAssetSlotRelease2 :: AssetSlot -> EffectiveRelease  -- TODO: use this throughout?
 getAssetSlotRelease2 as =
   let
-    pubRel = 
-      fold 
-        (case as of
-           AssetSlot a (Just s) ->
-             getAssetReleaseMaybe a <|> getSlotReleaseMaybe s
-           AssetSlot a Nothing ->
-             if volumeId (volumeRow $ assetVolume a) == Id 0
-             then getAssetReleaseMaybe a
-             else Nothing) -- "deleted" assets are always unreleased (private?), not view a
+    pubRel = fold (getAssetSlotReleaseMaybe as)
   in
     EffectiveRelease { effRelPublic = pubRel, effRelPrivate = ReleasePRIVATE }
     

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -9,6 +9,7 @@ module Databrary.Model.AssetSlot.Types
   , getAssetSlotVolumePermission2
   , getAssetSlotRelease
   , getAssetSlotReleaseMaybe
+  , getAssetSlotRelease2
   ) where
 
 import Control.Applicative ((<|>))
@@ -91,6 +92,23 @@ getAssetSlotReleaseMaybe as =
          if volumeId (volumeRow $ assetVolume a) == Id 0
          then getAssetReleaseMaybe a
          else Nothing) -- "deleted" assets are always unreleased (private?), not view a
+
+getAssetSlotRelease2 :: AssetSlot -> EffectiveRelease  -- TODO: use this throughout?
+getAssetSlotRelease2 as =
+  let
+    pubRel = 
+      fold 
+        (case as of
+           AssetSlot a (Just s) ->
+             getAssetReleaseMaybe a <|> getSlotReleaseMaybe s
+           AssetSlot a Nothing ->
+             if volumeId (volumeRow $ assetVolume a) == Id 0
+             then getAssetReleaseMaybe a
+             else Nothing) -- "deleted" assets are always unreleased (private?), not view a
+  in
+    EffectiveRelease { effRelPublic = pubRel, effRelPrivate = ReleasePRIVATE }
+    
+      
 {-
 instance Has (Maybe Release) AssetSlot where
   view (AssetSlot a (Just s)) = view a <|> view s

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -9,6 +9,8 @@ module Databrary.Model.AssetSlot.Types
   , getAssetSlotRelease
   , getAssetSlotReleaseMaybe
   , getAssetSlotRelease2
+  -- for testing only
+  , testgetAssetSlotRelease2
   ) where
 
 import Control.Applicative ((<|>))
@@ -24,6 +26,7 @@ import Databrary.Model.Container.Types
 import Databrary.Model.Format.Types
 import Databrary.Model.Asset.Types
 import Databrary.Model.Slot.Types
+import Databrary.Model.Asset (blankAsset)
 
 data AssetSlotId = AssetSlotId
   { slotAssetId :: !(Id Asset)
@@ -72,6 +75,46 @@ instance Has (Maybe Segment) AssetSlot where
   view = fmap view . assetSlot
 instance Has Segment AssetSlot where
   view = maybe fullSegment slotSegment . assetSlot
+
+-- TODO: move to unit test suite
+testmakeAssetSlot :: AssetSlot
+testmakeAssetSlot =
+  AssetSlot {
+      slotAsset = testmakeAsset
+    , assetSlot = Nothing -- Just testMakeSlot
+  }
+
+testmakeAsset :: Asset
+testmakeAsset =
+  blankAsset (testmakeVolume)
+
+testmakeVolume :: Volume
+testmakeVolume =
+  blankVolume {
+    volumeRow =
+      (volumeRow blankVolume) {
+          volumeId = Id 0
+        }
+    }
+
+-- test cases:
+-- no slot
+--    volume id > 0  (why ignore release when the asset is part of a volume?)
+--    volume id == 0 ? (mean general asset, not attached to a volume such as an avatar??)
+--       asset has no release
+--       asset has release with value ....
+-- has slot
+--    asset has no release
+--      slot's container has release
+--      slot's container has no release
+--    asset has release with value ...
+
+testgetAssetSlotRelease2 :: [(EffectiveRelease, EffectiveRelease)]
+testgetAssetSlotRelease2 =
+  [ (getAssetSlotRelease2 (testmakeAssetSlot), EffectiveRelease ReleasePRIVATE ReleasePRIVATE)
+  ]
+
+-- END TODO
 
 getAssetSlotRelease :: AssetSlot -> Release  -- TODO: Delete this and fix usages
 getAssetSlotRelease as =

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -4,6 +4,8 @@ module Databrary.Model.AssetSlot.Types
   , AssetSlot(..)
   , assetSlotId
   , assetNoSlot
+  , getAssetSlotVolume
+  , getAssetSlotVolumePermission
   ) where
 
 import Control.Applicative ((<|>))
@@ -49,8 +51,12 @@ instance Has (Id Format) AssetSlot where
   view = view . slotAsset
 instance Has Volume AssetSlot where
   view = view . slotAsset
+getAssetSlotVolume :: AssetSlot -> Volume
+getAssetSlotVolume = assetVolume . slotAsset
 instance Has (Id Volume) AssetSlot where
   view = view . slotAsset
+getAssetSlotVolumePermission :: AssetSlot -> Permission
+getAssetSlotVolumePermission = volumePermission . getAssetSlotVolume
 instance Has Permission AssetSlot where
   view = view . slotAsset
 

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -5,7 +5,6 @@ module Databrary.Model.AssetSlot.Types
   , assetSlotId
   , assetNoSlot
   , getAssetSlotVolume
-  -- , getAssetSlotVolumePermission
   , getAssetSlotVolumePermission2
   , getAssetSlotRelease
   , getAssetSlotReleaseMaybe
@@ -93,14 +92,4 @@ getAssetSlotRelease2 as =
     pubRel = fold (getAssetSlotReleaseMaybe as)
   in
     EffectiveRelease { effRelPublic = pubRel, effRelPrivate = ReleasePRIVATE }
-    
       
-{-
-instance Has (Maybe Release) AssetSlot where
-  view (AssetSlot a (Just s)) = view a <|> view s
-  view (AssetSlot a Nothing)
-    | volumeId (volumeRow $ assetVolume a) == Id 0 = view a
-    | otherwise = Nothing -- "deleted" assets are always unreleased (private?), not view a
-instance Has Release AssetSlot where
-  view = view . (view :: AssetSlot -> Maybe Release)
--}

--- a/Databrary/Model/AssetSlot/Types.hs
+++ b/Databrary/Model/AssetSlot/Types.hs
@@ -80,41 +80,75 @@ instance Has Segment AssetSlot where
 testmakeAssetSlot :: Asset -> Maybe Slot -> AssetSlot
 testmakeAssetSlot a ms = AssetSlot { slotAsset = a , assetSlot = ms }
 
-testmakeAsset :: Volume -> Asset
-testmakeAsset vol =
-  blankAsset vol
+testmakeAsset :: Volume -> Maybe Release -> Asset
+testmakeAsset vol mRel =
+  let asset = blankAsset vol
+  in asset { assetRow = (assetRow asset) { assetRelease = mRel } }
 
 testmakeVolume :: Id Volume -> Volume
 testmakeVolume vid =
   blankVolume {
     volumeRow =
-      (volumeRow blankVolume) {
-          volumeId = vid
-        }
+      (volumeRow blankVolume) { volumeId = vid }
+    }
+
+testmakeSlot :: Maybe Release -> Slot
+testmakeSlot mRel =
+  Slot { slotContainer = testmakeContainer mRel, slotSegment = fullSegment }
+
+testmakeContainer :: Maybe Release -> Container
+testmakeContainer mRel =
+  Container {
+      containerRow = ContainerRow { containerId = Id 200, containerTop = False, containerName = Nothing, containerDate = Nothing }
+    , containerRelease = mRel
+    , containerVolume = realVolume
     }
 
 realVolume, databrarySystem :: Volume
 realVolume = testmakeVolume (Id 100)
 databrarySystem = testmakeVolume coreVolumeId
 
+containerDeletedPointerToFormerVolume, avatarAttachedToDatabrarySystemNoRelease :: AssetSlot
+avatarAttachedToDatabrarySystemHasRelease :: AssetSlot
+-- inContainerHasAssetRelease, inContainerOnlyContainerRelease :: AssetSlot
+inContainerNoAsssetOrContainerRelease :: AssetSlot
+containerDeletedPointerToFormerVolume = testmakeAssetSlot (testmakeAsset realVolume Nothing) Nothing
+avatarAttachedToDatabrarySystemNoRelease = testmakeAssetSlot (testmakeAsset databrarySystem Nothing) Nothing
+avatarAttachedToDatabrarySystemHasRelease = testmakeAssetSlot (testmakeAsset databrarySystem (Just ReleasePUBLIC)) Nothing
+inContainerHasAssetRelease =
+  testmakeAssetSlot (testmakeAsset realVolume (Just ReleasePUBLIC)) (Just (testmakeSlot Nothing))
+inContainerOnlyContainerRelease =
+  testmakeAssetSlot (testmakeAsset realVolume Nothing) (Just (testmakeSlot (Just ReleaseSHARED)))
+inContainerNoAsssetOrContainerRelease =
+  testmakeAssetSlot (testmakeAsset realVolume Nothing) (Just (testmakeSlot Nothing))
+
 -- test cases:
 -- no slot  -- not part of a session (any longer)
---    volume id > 0  (if asset is tied to a volume, then it was deleted, so its release is always private)
-containerDeletedPointerToFormerVolume :: AssetSlot
-containerDeletedPointerToFormerVolume =
-  testmakeAssetSlot (testmakeAsset realVolume) Nothing
+--    volume id > 0  (if asset is tied to a volume, then it was deleted, so its release is always private) - DONE
 --    volume id == 0 ? (mean general asset, not attached to a real volume such as an avatar??)
---       asset has no release
---       asset has release with value ....
+--       asset has no release -- DONE
+--       asset has release with value .... -- DONE
 -- has slot  -- is part of a session
---    asset has no release
---      slot's container has release
---      slot's container has no release
---    asset has release with value ...
+--    asset has no release 
+--      slot's container has release  -- DONE
+--      slot's container has no release  -- DONE
+--    asset has release with value -- DONE
+-- Question: should the actual release value have any influence over the effective release's private release level?
+
+assetReleaseForFullySharedOnly, privateReleaseIgnoreSharing :: EffectiveRelease
+containerReleaseForFullySharedOnly :: EffectiveRelease
+assetReleaseForFullySharedOnly = EffectiveRelease ReleasePUBLIC ReleasePRIVATE
+containerReleaseForFullySharedOnly = EffectiveRelease ReleaseSHARED ReleasePRIVATE
+privateReleaseIgnoreSharing = EffectiveRelease ReleasePRIVATE ReleasePRIVATE
 
 testgetAssetSlotRelease2 :: [(EffectiveRelease, EffectiveRelease)]
 testgetAssetSlotRelease2 =
-  [ (getAssetSlotRelease2 containerDeletedPointerToFormerVolume, EffectiveRelease ReleasePRIVATE ReleasePRIVATE)
+  [ (getAssetSlotRelease2 containerDeletedPointerToFormerVolume, privateReleaseIgnoreSharing)
+  , (getAssetSlotRelease2 avatarAttachedToDatabrarySystemHasRelease, assetReleaseForFullySharedOnly) -- correct?
+  , (getAssetSlotRelease2 avatarAttachedToDatabrarySystemNoRelease, privateReleaseIgnoreSharing)
+  , (getAssetSlotRelease2 inContainerHasAssetRelease, assetReleaseForFullySharedOnly) -- correct?
+  , (getAssetSlotRelease2 inContainerOnlyContainerRelease, containerReleaseForFullySharedOnly) -- correct?
+  , (getAssetSlotRelease2 inContainerNoAsssetOrContainerRelease, privateReleaseIgnoreSharing)
   ]
 
 -- END TODO

--- a/Databrary/Model/Container.hs
+++ b/Databrary/Model/Container.hs
@@ -92,7 +92,9 @@ removeContainer c = do
     else isRight <$> dbTryJust (guard . isForeignKeyViolation) (dbExecute1 $(deleteContainer 'ident 'c))
 
 getContainerDate :: Container -> Maybe MaskedDate
-getContainerDate c = maskDateIf (dataPermission c == PermissionNONE) <$> containerDate (containerRow c)
+getContainerDate c =
+  maskDateIf (dataPermission2 getContainerRelease getContainerVolumePermission c == PermissionNONE)
+    <$> containerDate (containerRow c)
 
 formatContainerDate :: Container -> Maybe String
 formatContainerDate c = formatTime defaultTimeLocale "%Y-%m-%d" <$> getContainerDate c

--- a/Databrary/Model/Container.hs
+++ b/Databrary/Model/Container.hs
@@ -93,7 +93,7 @@ removeContainer c = do
 
 getContainerDate :: Container -> Maybe MaskedDate
 getContainerDate c =
-  maskDateIf (dataPermission2 getContainerRelease getContainerVolumePermission c == PermissionNONE)
+  maskDateIf (dataPermission3 getContainerRelease getContainerVolumePermission c == PermissionNONE)
     <$> containerDate (containerRow c)
 
 formatContainerDate :: Container -> Maybe String

--- a/Databrary/Model/Container.hs
+++ b/Databrary/Model/Container.hs
@@ -93,7 +93,7 @@ removeContainer c = do
 
 getContainerDate :: Container -> Maybe MaskedDate
 getContainerDate c =
-  maskDateIf (dataPermission3 getContainerRelease getContainerVolumePermission c == PermissionNONE)
+  maskDateIf (not (canReadData getContainerRelease getContainerVolumePermission c))
     <$> containerDate (containerRow c)
 
 formatContainerDate :: Container -> Maybe String

--- a/Databrary/Model/Container/Types.hs
+++ b/Databrary/Model/Container/Types.hs
@@ -2,16 +2,20 @@
 module Databrary.Model.Container.Types
   ( ContainerRow(..)
   , Container(..)
+  , getContainerVolumePermission
+  , getContainerRelease
   ) where
 
+import Data.Foldable (fold)
 import qualified Data.Text as T
 
-import Databrary.Has (makeHasRec)
+import Databrary.Has (makeHasRec, view)
 import Databrary.Model.Time
 import Databrary.Model.Kind
 import Databrary.Model.Release.Types
 import Databrary.Model.Id.Types
 import Databrary.Model.Volume.Types
+import Databrary.Model.Permission.Types
 
 type instance IdType Container = Int32
 
@@ -27,6 +31,12 @@ data Container = Container
   , containerRelease :: Maybe Release
   , containerVolume :: Volume
   }
+
+getContainerVolumePermission :: Container -> Permission
+getContainerVolumePermission = volumePermission . containerVolume
+
+getContainerRelease :: Container -> Release
+getContainerRelease = fold . containerRelease
 
 instance Kinded Container where
   kindOf _ = "container"

--- a/Databrary/Model/Container/Types.hs
+++ b/Databrary/Model/Container/Types.hs
@@ -32,11 +32,15 @@ data Container = Container
   , containerVolume :: Volume
   }
 
-getContainerVolumePermission :: Container -> Permission
-getContainerVolumePermission = volumePermission . containerVolume
+getContainerVolumePermission :: Container -> (Permission, VolumeAccessPolicy)
+getContainerVolumePermission = volumePermissionPolicy . containerVolume
 
-getContainerRelease :: Container -> Release
-getContainerRelease = fold . containerRelease
+getContainerRelease :: Container -> EffectiveRelease
+getContainerRelease c =  
+  EffectiveRelease {
+      effRelPublic = (fold . containerRelease) c
+    , effRelPrivate = ReleasePRIVATE -- TODO: name hardcoded default level for Private release centrally
+    }
 
 instance Kinded Container where
   kindOf _ = "container"

--- a/Databrary/Model/Format.hs
+++ b/Databrary/Model/Format.hs
@@ -4,7 +4,7 @@ module Databrary.Model.Format
   , mimeTypeTop
   , mimeTypeSub
   , mimeTypeTopCompare
-  , unknownFormat
+  -- , unknownFormat
   , allFormats
   , getFormat
   , getFormat'
@@ -55,14 +55,6 @@ mimeTypeTopCompare a b = mttc (BSC.unpack a) (BSC.unpack b) where
   mttc _       ('/':_) = GT
   mttc _       []      = GT
   mttc (ac:as) (bc:bs) = compare ac bc <> mttc as bs
-
-unknownFormat :: Format
-unknownFormat = Format
-  { formatId = error "unknownFormat"
-  , formatMimeType = "application/octet-stream"
-  , formatExtension = []
-  , formatName = "Unknown"
-  }
 
 allFormats :: [Format]
 allFormats = $(loadFormats)

--- a/Databrary/Model/Format/Types.hs
+++ b/Databrary/Model/Format/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell, OverloadedStrings, TypeFamilies #-}
 module Databrary.Model.Format.Types
   ( Format(..)
+  , unknownFormat
   ) where
 
 import qualified Data.ByteString as BS
@@ -37,3 +38,12 @@ instance Ord Format where
 
 makeHasRec ''Format ['formatId]
 deriveLift ''Format
+
+unknownFormat :: Format
+unknownFormat = Format
+  { formatId = error "unknownFormat"
+  , formatMimeType = "application/octet-stream"
+  , formatExtension = []
+  , formatName = "Unknown"
+  }
+

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -76,6 +76,7 @@ excerptsReleasedAssetOrExcerpt = (ReleaseEXCERPTS, ReleasePRIVATE)  -- is it pos
 databraryReleasedAssetOrExcerpt = (ReleaseSHARED, ReleasePRIVATE)  -- is this shared or private?
 privatelyReleasedAssetOrExcerpt = (ReleasePRIVATE, ReleasePRIVATE)
 
+testdataPermission3 :: [(Permission, Permission)]
 testdataPermission3 =
   [ (runDataPermission3 publiclyReleasedExcerpt fullySharedAsPublic, PermissionPUBLIC)
   , (runDataPermission3 publiclyReleasedExcerpt partiallySharedAsPublic, PermissionPUBLIC)

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -45,8 +45,8 @@ readRelease _                = Just ReleasePRIVATE
 
 -- |The effective permission for data objects with the given attributes, effectively collapsing ineffective permissions NONE.
 releasePermission :: Release -> Permission -> Permission
-releasePermission r p
-  | p >= readPermission r = p
+releasePermission effectiveReleaseOnData currentUserAllowedPermissionOnVolume
+  | currentUserAllowedPermissionOnVolume >= readPermission effectiveReleaseOnData = currentUserAllowedPermissionOnVolume
   | otherwise = PermissionNONE
 
 -- START future testing code

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -6,8 +6,6 @@ module Databrary.Model.Permission
   , permissionPRIVATE
   , readPermission
   , readRelease
-  -- , dataPermission
-  -- , dataPermission2
   , dataPermission3
   , accessJSON
   ) where
@@ -48,15 +46,6 @@ releasePermission :: Release -> Permission -> Permission
 releasePermission r p
   | p >= readPermission r = p
   | otherwise = PermissionNONE
-
-{-
-dataPermission :: (Has Release a, Has Permission a) => a -> Permission
-dataPermission a = releasePermission (view a) (view a)
-dataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> Permission
-dataPermission2 getObjRelease getCurrentUserPermLevel obj =
-  releasePermission (getObjRelease obj) (getCurrentUserPermLevel obj)
--}
-
 
 dataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> Permission
 dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj =

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -6,7 +6,7 @@ module Databrary.Model.Permission
   , permissionPRIVATE
   , readPermission
   , readRelease
-  , dataPermission
+  -- , dataPermission
   , dataPermission2
   , accessJSON
   ) where
@@ -48,8 +48,10 @@ releasePermission r p
   | p >= readPermission r = p
   | otherwise = PermissionNONE
 
+{-
 dataPermission :: (Has Release a, Has Permission a) => a -> Permission
 dataPermission a = releasePermission (view a) (view a)
+-}
 
 dataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> Permission
 dataPermission2 getObjRelease getCurrentUserPermLevel obj =

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -8,6 +8,7 @@ module Databrary.Model.Permission
   , readRelease
   -- , dataPermission
   , dataPermission2
+  , dataPermission3
   , accessJSON
   ) where
 
@@ -56,6 +57,16 @@ dataPermission a = releasePermission (view a) (view a)
 dataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> Permission
 dataPermission2 getObjRelease getCurrentUserPermLevel obj =
   releasePermission (getObjRelease obj) (getCurrentUserPermLevel obj)
+
+dataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> Permission
+dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj =
+  let
+    effRelease = getObjEffectiveRelease obj
+  in 
+    case getCurrentUserPermLevel obj of
+      (p@PermissionPUBLIC, PublicRestricted) -> releasePermission (effRelPrivate effRelease) p
+      -- other levels that behave more like private (options: none, shared, read, edit, admin) ? 
+      (p, _) -> releasePermission (effRelPublic effRelease) p
 
 accessJSON :: JSON.ToObject o => Access -> o
 accessJSON Access{..} =

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -7,7 +7,7 @@ module Databrary.Model.Permission
   , readPermission
   , readRelease
   -- , dataPermission
-  , dataPermission2
+  -- , dataPermission2
   , dataPermission3
   , accessJSON
   ) where
@@ -52,11 +52,11 @@ releasePermission r p
 {-
 dataPermission :: (Has Release a, Has Permission a) => a -> Permission
 dataPermission a = releasePermission (view a) (view a)
--}
-
 dataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> Permission
 dataPermission2 getObjRelease getCurrentUserPermLevel obj =
   releasePermission (getObjRelease obj) (getCurrentUserPermLevel obj)
+-}
+
 
 dataPermission3 :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> Permission
 dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj =

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -7,6 +7,7 @@ module Databrary.Model.Permission
   , readPermission
   , readRelease
   , dataPermission3
+  , canReadData
   , accessJSON
   -- testing only
   , testdataPermission3
@@ -111,6 +112,11 @@ dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj =
       (p@PermissionPUBLIC, PublicRestricted) -> releasePermission (effRelPrivate effRelease) p
       -- other levels that behave more like private (options: none, shared, read, edit, admin) ? 
       (p, _) -> releasePermission (effRelPublic effRelease) p
+
+canReadData :: (a -> EffectiveRelease) -> (a -> (Permission, VolumeAccessPolicy)) -> a -> Bool
+canReadData getObjEffectiveRelease getCurrentUserPermLevel obj =
+  dataPermission3 getObjEffectiveRelease getCurrentUserPermLevel obj > PermissionNONE
+
 
 accessJSON :: JSON.ToObject o => Access -> o
 accessJSON Access{..} =

--- a/Databrary/Model/Permission.hs
+++ b/Databrary/Model/Permission.hs
@@ -7,6 +7,7 @@ module Databrary.Model.Permission
   , readPermission
   , readRelease
   , dataPermission
+  , dataPermission2
   , accessJSON
   ) where
 
@@ -49,6 +50,10 @@ releasePermission r p
 
 dataPermission :: (Has Release a, Has Permission a) => a -> Permission
 dataPermission a = releasePermission (view a) (view a)
+
+dataPermission2 :: (a -> Release) -> (a -> Permission) -> a -> Permission
+dataPermission2 getObjRelease getCurrentUserPermLevel obj =
+  releasePermission (getObjRelease obj) (getCurrentUserPermLevel obj)
 
 accessJSON :: JSON.ToObject o => Access -> o
 accessJSON Access{..} =

--- a/Databrary/Model/Permission/Types.hs
+++ b/Databrary/Model/Permission/Types.hs
@@ -4,6 +4,7 @@ module Databrary.Model.Permission.Types
   ( Permission(..)
   , Access(..), accessPermission'
   , accessSite, accessMember, accessPermission
+  , VolumeAccessPolicy(..)
   ) where
 
 import Language.Haskell.TH.Lift (deriveLiftMany)
@@ -39,3 +40,6 @@ instance Monoid Access where
   mappend (Access s1 m1) (Access s2 m2) = Access (mappend s1 s2) (mappend m1 m2)
 
 deriveLiftMany [''Permission, ''Access]
+
+data VolumeAccessPolicy = PublicRestricted | PermLevelDefault
+  deriving (Show, Eq)

--- a/Databrary/Model/Record/Types.hs
+++ b/Databrary/Model/Record/Types.hs
@@ -2,6 +2,7 @@
 module Databrary.Model.Record.Types
   ( RecordRow(..)
   , Record(..)
+  , getRecordVolumePermission
   , Measure(..)
   , Measures
   ) where
@@ -48,6 +49,8 @@ type Measures = [Measure]
 
 makeHasRec ''RecordRow ['recordId, 'recordCategory]
 makeHasRec ''Record ['recordRow, 'recordVolume, 'recordRelease]
+getRecordVolumePermission :: Record -> Permission
+getRecordVolumePermission = volumePermission . recordVolume
 
 instance Has Record Measure where
   view = measureRecord

--- a/Databrary/Model/Record/Types.hs
+++ b/Databrary/Model/Record/Types.hs
@@ -49,8 +49,8 @@ type Measures = [Measure]
 
 makeHasRec ''RecordRow ['recordId, 'recordCategory]
 makeHasRec ''Record ['recordRow, 'recordVolume, 'recordRelease]
-getRecordVolumePermission :: Record -> Permission
-getRecordVolumePermission = volumePermission . recordVolume
+getRecordVolumePermission :: Record -> (Permission, VolumeAccessPolicy)
+getRecordVolumePermission = volumePermissionPolicy . recordVolume
 
 instance Has Record Measure where
   view = measureRecord

--- a/Databrary/Model/RecordSlot.hs
+++ b/Databrary/Model/RecordSlot.hs
@@ -97,7 +97,7 @@ recordSlotAge rs@RecordSlot{..} =
   clip <$> liftM2 age (decodeMeasure (PGTypeProxy :: PGTypeName "date") =<< getMeasure birthdateMetric (recordMeasures slotRecord)) (containerDate $ containerRow $ slotContainer recordSlot)
   where
   clip a
-    | dataPermission rs == PermissionNONE = a `min` ageLimit
+    | dataPermission2 getRecordSlotRelease getRecordSlotVolumePermission rs == PermissionNONE = a `min` ageLimit
     | otherwise = a
 
 recordSlotJSON :: JSON.ToObject o => Bool -> RecordSlot -> JSON.Record (Id Record) o

--- a/Databrary/Model/RecordSlot.hs
+++ b/Databrary/Model/RecordSlot.hs
@@ -97,7 +97,7 @@ recordSlotAge rs@RecordSlot{..} =
   clip <$> liftM2 age (decodeMeasure (PGTypeProxy :: PGTypeName "date") =<< getMeasure birthdateMetric (recordMeasures slotRecord)) (containerDate $ containerRow $ slotContainer recordSlot)
   where
   clip a
-    | dataPermission2 getRecordSlotRelease getRecordSlotVolumePermission rs == PermissionNONE = a `min` ageLimit
+    | dataPermission3 getRecordSlotRelease getRecordSlotVolumePermission rs == PermissionNONE = a `min` ageLimit
     | otherwise = a
 
 recordSlotJSON :: JSON.ToObject o => Bool -> RecordSlot -> JSON.Record (Id Record) o

--- a/Databrary/Model/RecordSlot.hs
+++ b/Databrary/Model/RecordSlot.hs
@@ -97,7 +97,7 @@ recordSlotAge rs@RecordSlot{..} =
   clip <$> liftM2 age (decodeMeasure (PGTypeProxy :: PGTypeName "date") =<< getMeasure birthdateMetric (recordMeasures slotRecord)) (containerDate $ containerRow $ slotContainer recordSlot)
   where
   clip a
-    | dataPermission3 getRecordSlotRelease getRecordSlotVolumePermission rs == PermissionNONE = a `min` ageLimit
+    | not (canReadData getRecordSlotRelease getRecordSlotVolumePermission rs) = a `min` ageLimit
     | otherwise = a
 
 recordSlotJSON :: JSON.ToObject o => Bool -> RecordSlot -> JSON.Record (Id Record) o

--- a/Databrary/Model/RecordSlot/Types.hs
+++ b/Databrary/Model/RecordSlot/Types.hs
@@ -47,10 +47,10 @@ instance Has Volume RecordSlot where
   view = view . slotRecord
 instance Has (Id Volume) RecordSlot where
   view = view . slotRecord
-getRecordSlotVolumePermission :: RecordSlot -> Permission
+getRecordSlotVolumePermission :: RecordSlot -> (Permission, VolumeAccessPolicy)
 getRecordSlotVolumePermission = getRecordVolumePermission . slotRecord
-instance Has Permission RecordSlot where
-  view = view . slotRecord
+-- instance Has Permission RecordSlot where
+--   view = view . slotRecord
 
 instance Has Slot RecordSlot where
   view = recordSlot
@@ -61,11 +61,9 @@ instance Has (Id Container) RecordSlot where
 instance Has Segment RecordSlot where
   view = view . recordSlot
 
-getRecordSlotRelease :: RecordSlot -> Release
+getRecordSlotRelease :: RecordSlot -> EffectiveRelease
 getRecordSlotRelease rs =
-  fold (view (recordSlot rs) <|> view (slotRecord rs) :: Maybe Release)
-instance Has (Maybe Release) RecordSlot where
-  view rs = view (recordSlot rs) <|> view (slotRecord rs)
-instance Has Release RecordSlot where
-  view = view . (view :: RecordSlot -> Maybe Release)
-
+  EffectiveRelease {
+      effRelPublic = fold (view (recordSlot rs) <|> view (slotRecord rs) :: Maybe Release)
+    , effRelPrivate = ReleasePRIVATE
+  }

--- a/Databrary/Model/RecordSlot/Types.hs
+++ b/Databrary/Model/RecordSlot/Types.hs
@@ -49,8 +49,6 @@ instance Has (Id Volume) RecordSlot where
   view = view . slotRecord
 getRecordSlotVolumePermission :: RecordSlot -> (Permission, VolumeAccessPolicy)
 getRecordSlotVolumePermission = getRecordVolumePermission . slotRecord
--- instance Has Permission RecordSlot where
---   view = view . slotRecord
 
 instance Has Slot RecordSlot where
   view = recordSlot

--- a/Databrary/Model/RecordSlot/Types.hs
+++ b/Databrary/Model/RecordSlot/Types.hs
@@ -2,9 +2,12 @@
 module Databrary.Model.RecordSlot.Types
   ( RecordSlot(..)
   , recordSlotId
+  , getRecordSlotVolumePermission
+  , getRecordSlotRelease
   ) where
 
 import Control.Applicative ((<|>))
+import Data.Foldable (fold)
 
 import Databrary.Has (Has(..))
 import Databrary.Model.Id.Types
@@ -44,6 +47,8 @@ instance Has Volume RecordSlot where
   view = view . slotRecord
 instance Has (Id Volume) RecordSlot where
   view = view . slotRecord
+getRecordSlotVolumePermission :: RecordSlot -> Permission
+getRecordSlotVolumePermission = getRecordVolumePermission . slotRecord
 instance Has Permission RecordSlot where
   view = view . slotRecord
 
@@ -56,6 +61,9 @@ instance Has (Id Container) RecordSlot where
 instance Has Segment RecordSlot where
   view = view . recordSlot
 
+getRecordSlotRelease :: RecordSlot -> Release
+getRecordSlotRelease rs =
+  fold (view (recordSlot rs) <|> view (slotRecord rs) :: Maybe Release)
 instance Has (Maybe Release) RecordSlot where
   view rs = view (recordSlot rs) <|> view (slotRecord rs)
 instance Has Release RecordSlot where

--- a/Databrary/Model/Release/Types.hs
+++ b/Databrary/Model/Release/Types.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Databrary.Model.Release.Types
   ( Release(..)
+  , EffectiveRelease(..)
   ) where
 
 import Data.Foldable (fold)
@@ -20,3 +21,9 @@ instance Has Release (Maybe Release) where
   view = fold
 
 deriveLift ''Release
+
+data EffectiveRelease =
+       EffectiveRelease {
+           effRelPublic :: !Release
+         , effRelPrivate :: !Release
+         } deriving (Eq, Show)

--- a/Databrary/Model/Slot/Types.hs
+++ b/Databrary/Model/Slot/Types.hs
@@ -5,6 +5,7 @@ module Databrary.Model.Slot.Types
   , slotId
   , containerSlotId
   , containerSlot
+  , getSlotReleaseMaybe
   ) where
 
 import Databrary.Has (makeHasRec)
@@ -12,6 +13,7 @@ import Databrary.Model.Id
 import Databrary.Model.Kind
 import Databrary.Model.Segment
 import Databrary.Model.Container.Types
+import Databrary.Model.Release.Types
 
 data SlotId = SlotId
   { slotContainerId :: !(Id Container)
@@ -41,3 +43,5 @@ instance Kinded Slot where
 
 makeHasRec ''SlotId ['slotContainerId, 'slotSegmentId]
 makeHasRec ''Slot ['slotContainer, 'slotSegment]
+getSlotReleaseMaybe :: Slot -> Maybe Release
+getSlotReleaseMaybe = containerRelease . slotContainer

--- a/Databrary/Model/Volume.hs
+++ b/Databrary/Model/Volume.hs
@@ -41,7 +41,7 @@ import Databrary.Model.Volume.Boot
 import Databrary.Model.VolumeAccess.Types (VolumeAccess(..))
 
 coreVolume :: Volume
-coreVolume = $(loadVolume (Id 0))
+coreVolume = $(loadVolume coreVolumeId)
 
 lookupVolume :: (MonadDB c m, MonadHasIdentity c m) => Id Volume -> m (Maybe Volume)
 lookupVolume vi = do

--- a/Databrary/Model/Volume/Types.hs
+++ b/Databrary/Model/Volume/Types.hs
@@ -5,7 +5,7 @@ module Databrary.Model.Volume.Types
   , VolumeOwner
   , blankVolume
   , volumePermissionPolicy
-  , VolumeAccessPolicy(..)
+  -- , VolumeAccessPolicy(..)
   , volumeAccessPolicyWithDefault
   ) where
 
@@ -35,8 +35,8 @@ data VolumeRow = VolumeRow
 
 type VolumeOwner = (Id Party, T.Text)
 
-data VolumeAccessPolicy = PublicRestricted | PermLevelDefault
-  deriving (Show, Eq)
+-- data VolumeAccessPolicy = PublicRestricted | PermLevelDefault
+--   deriving (Show, Eq)
 
 data Volume = Volume
   { volumeRow :: !VolumeRow

--- a/Databrary/Model/Volume/Types.hs
+++ b/Databrary/Model/Volume/Types.hs
@@ -5,7 +5,6 @@ module Databrary.Model.Volume.Types
   , VolumeOwner
   , blankVolume
   , volumePermissionPolicy
-  -- , VolumeAccessPolicy(..)
   , volumeAccessPolicyWithDefault
   ) where
 
@@ -34,9 +33,6 @@ data VolumeRow = VolumeRow
   deriving (Show)
 
 type VolumeOwner = (Id Party, T.Text)
-
--- data VolumeAccessPolicy = PublicRestricted | PermLevelDefault
---   deriving (Show, Eq)
 
 data Volume = Volume
   { volumeRow :: !VolumeRow

--- a/Databrary/Model/Volume/Types.hs
+++ b/Databrary/Model/Volume/Types.hs
@@ -6,6 +6,7 @@ module Databrary.Model.Volume.Types
   , blankVolume
   , volumePermissionPolicy
   , volumeAccessPolicyWithDefault
+  , coreVolumeId
   ) where
 
 import qualified Data.ByteString as BS
@@ -79,3 +80,6 @@ blankVolume = Volume
   , volumePermission = PermissionNONE
   , volumeAccessPolicy = PermLevelDefault
   }
+
+coreVolumeId :: Id Volume
+coreVolumeId = Id 0

--- a/Databrary/View/Zip.hs
+++ b/Databrary/View/Zip.hs
@@ -171,7 +171,7 @@ htmlVolumeDescription inzip Volume{ volumeRow = VolumeRow{..}, ..} cite fund glo
       byteStringHtml fn
     H.td $ H.a H.! HA.href (link viewAsset (HTML, assetId a)) $
       H.text $ fromMaybe (formatName $ assetFormat a) $ assetName a
-    H.td $ H.string $ show (view as :: Release)
+    H.td $ H.string $ show (getAssetSlotRelease as :: Release)
     H.td $ maybe mempty H.toMarkup $ assetSize a
     H.td $ maybe mempty (H.string . show) $ assetDuration a
     H.td $ maybe mempty (lazyByteStringHtml . BSB.toLazyByteString . BSB.byteStringHex) $ assetSHA1 a

--- a/web/asset/display.coffee
+++ b/web/asset/display.coffee
@@ -13,7 +13,7 @@ app.directive 'assetDisplay', [
       $scope.readable = $scope.asset.checkPermission(constants.permission.VIEW)
       if $scope.$parent.publicView == true
         $scope.asset = $scope.asset.excerpts[0]
-      return
+        return
       if $scope.asset != asset
         $scope.clip = asset.segment.relativeTo($scope.asset.segment)
       return

--- a/web/asset/display.coffee
+++ b/web/asset/display.coffee
@@ -11,9 +11,6 @@ app.directive 'assetDisplay', [
       asset = $scope.assetFn()
       $scope.asset = if 'exact' of $attrs then asset else asset.inContext()
       $scope.readable = $scope.asset.checkPermission(constants.permission.VIEW)
-      if $scope.$parent.publicView == true
-        $scope.asset = $scope.asset.excerpts[0]
-        return
       if $scope.asset != asset
         $scope.clip = asset.segment.relativeTo($scope.asset.segment)
       return

--- a/web/volume/editAccess.html
+++ b/web/volume/editAccess.html
@@ -12,7 +12,7 @@
         <span message="access.preset.title{{::$index}}" tooltip="'access.preset.select{{::$index}}' | message"></span>
       </label>
     </div>
-    <div class="col message message-yellow message-content" ng-if="volumeEditAccessForm.preset===1">Only the volume title, description, collaborators (if any), citation information, file summary table, keywords, and comments will be shared. Go to the Overview tab to update.</div>
+    <div class="col message message-yellow message-content" ng-if="volumeEditAccessForm.preset===1">Only the volume title, description, public excerpts, collaborators (if any), citation information, file summary table, keywords, and comments will be shared. Go to the Overview tab to update.</div>
     <div class="col message message-yellow message-content" ng-if="volumeEditAccessForm.preset===2">All volume information, including data files, will be shared. (Access to individual files is still determined by file-level settings.)</div>
   </fieldset>
 

--- a/web/volume/excerpts.coffee
+++ b/web/volume/excerpts.coffee
@@ -20,8 +20,6 @@ app.directive 'volumeExcerpts', [
       else
         $scope.excerpts = [$scope.volume.excerpts]
 
-      $scope.publicView = true
-
       $scope.setCurrent = (asset) ->
         $scope.current = asset
 
@@ -35,5 +33,4 @@ app.directive 'volumeExcerpts', [
             persist: true
             body: message.map($sce.trustAsHtml)
         return
-
 ]

--- a/web/volume/view.html
+++ b/web/volume/view.html
@@ -2,7 +2,7 @@
   <panel top id="panel-overview-volume" panel-title="volume.overview.title">
     <volume-overview></volume-overview>
   </panel>
-  <panel id="panel-excerpts" panel-title="excerpts.title" fold ng-if="::(volume.excerpts.length || volume.checkPermission(page.permission.EDIT)) && checkpublicsharefull">
+  <panel id="panel-excerpts" panel-title="excerpts.title" fold ng-if="::(volume.excerpts.length || volume.checkPermission(page.permission.EDIT))">
     <volume-excerpts release></volume-excerpts>
   </panel>
   <panel id="panel-data" panel-title="data.title" ng-if="checkpublicsharefull" edit-link="{{::volume.checkPermission(page.permission.EDIT) ? volume.editRoute('data') : ''}}" fold>


### PR DESCRIPTION
At this point, the backend will allow access to an excerpt's video segment only by for partially shared volumes when public users are viewing.

Next steps:
- fix back end to always provide the correct segment when a segment is requested
- fix front end to only attempt to access the excerpt segment of a video in volume overview (and search?)

cc: @muji786 