### PR TITLE
Fix asset file names for stricter requirements of new library

### DIFF
--- a/src/Databrary/Controller/Asset.hs
+++ b/src/Databrary/Controller/Asset.hs
@@ -30,6 +30,8 @@ import qualified Database.PostgreSQL.Typed.Range as Range
 import Network.HTTP.Types (conflict409)
 import qualified Network.Wai as Wai
 import Network.Wai.Parse (FileInfo(..))
+import qualified System.FilePath.Posix as FPP (makeValid)
+import qualified System.FilePath.Windows as FPW (makeValid)
 
 import Databrary.Ops
 import Databrary.Has
@@ -123,7 +125,7 @@ assetDownloadName addPrefix trimFormat a =
 
 scrubAssetName :: T.Text -> T.Text
 scrubAssetName assetName =
-  T.filter (\c -> c /= ':') assetName
+  T.pack (FPW.makeValid (FPP.makeValid (T.unpack assetName))) -- needed for asset zip entry
 
 viewAsset :: ActionRoute (API, Id Asset)
 viewAsset = action GET (pathAPI </> pathId) $ \(api, i) -> withAuth $ do

--- a/src/Databrary/Controller/Asset.hs
+++ b/src/Databrary/Controller/Asset.hs
@@ -113,11 +113,17 @@ assetDownloadName addPrefix trimFormat a =
         -- original uploaded files have the extension embedded in the name
         then fmap (TE.decodeUtf8 . dropFormatExtension (assetFormat a) . TE.encodeUtf8) (assetName a)
         else assetName a
+    scrubbedAssetName :: Maybe T.Text
+    scrubbedAssetName =
+        fmap scrubAssetName assetName'
   in
     if addPrefix
-    then T.pack (show $ assetId a) : maybeToList assetName'
-    else maybeToList assetName'
+    then T.pack (show $ assetId a) : maybeToList scrubbedAssetName
+    else maybeToList scrubbedAssetName
 
+scrubAssetName :: T.Text -> T.Text
+scrubAssetName assetName =
+  T.filter (\c -> c /= ':') assetName
 
 viewAsset :: ActionRoute (API, Id Asset)
 viewAsset = action GET (pathAPI </> pathId) $ \(api, i) -> withAuth $ do

--- a/src/Databrary/Controller/Zip.hs
+++ b/src/Databrary/Controller/Zip.hs
@@ -79,7 +79,7 @@ assetZipEntry2 isOrig containerDir AssetSlot{ slotAsset = a@Asset{ assetRow = ar
     (do
        ZIP.sinkEntry ZIP.Store (CND.sourceFileBS (BSC.unpack f)) entrySelector
        ZIP.setEntryComment (TE.decodeUtf8 $ BSL.toStrict $ BSB.toLazyByteString $ actionURL (Just req) viewAsset (HTML, assetId ar) []) entrySelector)
-  
+
 containerZipEntry2 :: Bool -> BS.ByteString -> Container -> [AssetSlot] -> ActionM (ZIP.ZipArchive ())
 containerZipEntry2 isOrig prefix c l = do
   let containerDir = prefix <> makeFilename (containerDownloadName c) <> "/"


### PR DESCRIPTION
- new zip implementation uses a library that checks zip entry names
- handle colon character and other invalid characters/combinations

CC: @chreekat - this changed.