### PR TITLE
Enable cabal test in a nix-shell

### DIFF
--- a/databrary.cabal
+++ b/databrary.cabal
@@ -29,6 +29,7 @@ Flag sandbox
 library
   hs-source-dirs: src
   c-sources: src/Databrary/Store/avFrame.c
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   exposed-modules:
     Paths_databrary
     Blaze.ByteString.Builder.Html.Word
@@ -524,5 +525,18 @@ Executable generate
     ghc-options: -with-rtsopts -N
   if flag(sandbox)
     cpp-options: -DSANDBOX
+
+test-suite databrary-test
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  hs-source-dirs: test
+  build-depends:
+    databrary
+    , base
+    , tasty
+    , tasty-expected-failure
+    , tasty-hunit
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  default-language: Haskell2010
 
 -- vim: shiftwidth=2

--- a/databrary.nix
+++ b/databrary.nix
@@ -8,10 +8,11 @@
 , network, network-uri, openssl, parsec, path, path-io, posix-paths
 , postgresql-simple, postgresql-typed, process, range-set-list
 , regex-posix, resource-pool, resourcet, scientific, smtp-mail
-, stdenv, streaming-commons, template-haskell, text, th-lift
-, th-lift-instances, time, transformers, transformers-base, unix
-, unordered-containers, utf8-string, vector, wai, wai-extra, warp
-, warp-tls, web-inv-route, xml, zip, zlib
+, stdenv, streaming-commons, tasty, tasty-expected-failure
+, tasty-hunit, template-haskell, text, th-lift, th-lift-instances
+, time, transformers, transformers-base, unix, unordered-containers
+, utf8-string, vector, wai, wai-extra, warp, warp-tls
+, web-inv-route, xml, zip, zlib
 , gargoyle, gargoyle-postgresql, postgresql
 , nodePackages, nodejs, dbName ? "databrary-nix-db", jdk
 , cpio, coreutils
@@ -64,6 +65,9 @@ mkDerivation rec {
   executableSystemDepends = [ cracklib openssl openssl.dev ];
   executablePkgconfigDepends = [
     ffmpeg
+  ];
+  testHaskellDepends = [
+    base tasty tasty-expected-failure tasty-hunit
   ];
   executableToolDepends = [
     postgresql.postgres

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import Test.Tasty
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "databrary" []


### PR DESCRIPTION
Adds a no-op test that can be run with `nix-shell --run 'cabal -j new-test'`