### PR TITLE
Remove compile time fetching of db enum values

### DIFF
--- a/src/Databrary/Model/Audit/Types.hs
+++ b/src/Databrary/Model/Audit/Types.hs
@@ -7,13 +7,89 @@ module Databrary.Model.Audit.Types
   ) where
 
 import Database.PostgreSQL.Typed.Inet (PGInet)
+import qualified Data.Typeable.Internal
+import qualified GHC.Arr
+import qualified Database.PostgreSQL.Typed.Types
+import qualified Database.PostgreSQL.Typed.Dynamic
+import qualified Database.PostgreSQL.Typed.Enum
+import qualified Data.Aeson.Types
+import qualified Data.ByteString
+import qualified Data.ByteString.Char8
 
 import Databrary.Model.Time
 import Databrary.Model.Enum
 import Databrary.Model.Id.Types
 import Databrary.Model.Party.Types
+import qualified Databrary.Model.Kind
+import qualified Databrary.HTTP.Form.Deform
 
-makeDBEnum "audit.action" "AuditAction"
+-- makeDBEnum "audit.action" "AuditAction"
+data AuditAction
+  = AuditActionAttempt |
+    AuditActionOpen |
+    AuditActionClose |
+    AuditActionAdd |
+    AuditActionChange |
+    AuditActionRemove |
+    AuditActionSuperuser
+  deriving (Eq,
+            Ord,
+            Enum,
+            GHC.Arr.Ix,
+            Bounded,
+            Data.Typeable.Internal.Typeable)
+instance Show AuditAction where
+  show AuditActionAttempt = "attempt"
+  show AuditActionOpen = "open"
+  show AuditActionClose = "close"
+  show AuditActionAdd = "add"
+  show AuditActionChange = "change"
+  show AuditActionRemove = "remove"
+  show AuditActionSuperuser = "superuser"
+instance Database.PostgreSQL.Typed.Types.PGType "audit.action"
+instance Database.PostgreSQL.Typed.Types.PGParameter "audit.action" AuditAction where
+  pgEncode _ AuditActionAttempt
+    = Data.ByteString.pack [97, 116, 116, 101, 109, 112, 116]
+  pgEncode _ AuditActionOpen
+    = Data.ByteString.pack [111, 112, 101, 110]
+  pgEncode _ AuditActionClose
+    = Data.ByteString.pack [99, 108, 111, 115, 101]
+  pgEncode _ AuditActionAdd
+    = Data.ByteString.pack [97, 100, 100]
+  pgEncode _ AuditActionChange
+    = Data.ByteString.pack [99, 104, 97, 110, 103, 101]
+  pgEncode _ AuditActionRemove
+    = Data.ByteString.pack [114, 101, 109, 111, 118, 101]
+  pgEncode _ AuditActionSuperuser
+    = Data.ByteString.pack
+        [115, 117, 112, 101, 114, 117, 115, 101, 114]
+instance Database.PostgreSQL.Typed.Types.PGColumn "audit.action" AuditAction where
+  pgDecode _ x_a4NXQ
+    = case Data.ByteString.unpack x_a4NXQ of
+        [97, 116, 116, 101, 109, 112, 116] -> AuditActionAttempt
+        [111, 112, 101, 110] -> AuditActionOpen
+        [99, 108, 111, 115, 101] -> AuditActionClose
+        [97, 100, 100] -> AuditActionAdd
+        [99, 104, 97, 110, 103, 101] -> AuditActionChange
+        [114, 101, 109, 111, 118, 101] -> AuditActionRemove
+        [115, 117, 112, 101, 114, 117, 115, 101, 114]
+          -> AuditActionSuperuser
+        _ -> error
+               ("pgDecode audit.action: "
+                ++ (Data.ByteString.Char8.unpack x_a4NXQ))
+instance Database.PostgreSQL.Typed.Dynamic.PGRep "audit.action" AuditAction
+instance Database.PostgreSQL.Typed.Enum.PGEnum AuditAction
+instance Databrary.Model.Kind.Kinded AuditAction where
+  kindOf _ = "audit.action"
+instance DBEnum AuditAction
+instance Data.Aeson.Types.ToJSON AuditAction where
+  toJSON
+    = (Data.Aeson.Types.toJSON . fromEnum)
+instance Data.Aeson.Types.FromJSON AuditAction where
+  parseJSON = parseJSONEnum
+instance Databrary.HTTP.Form.Deform.Deform f_a4NXR AuditAction where
+  deform = enumForm
+
 
 data AuditIdentity = AuditIdentity
   { auditWho :: !(Id Party)

--- a/src/Databrary/Model/Enum.hs
+++ b/src/Databrary/Model/Enum.hs
@@ -2,7 +2,7 @@
 module Databrary.Model.Enum
   ( DBEnum
   , readDBEnum
-  , makeDBEnum
+  -- , makeDBEnum
   , parseJSONEnum
   , enumForm
   , pgEnumValues
@@ -54,6 +54,7 @@ enumForm = deformParse minBound fv where
   fv _ = e
   e = Left $ "Invalid " `T.append` kindOf (undefined :: a)
 
+{-
 makeDBEnum :: String -> String -> TH.DecsQ
 makeDBEnum name typs = do
   [] <- useTDB
@@ -71,3 +72,4 @@ makeDBEnum name typs = do
     |]
   where
   typt = TH.ConT (TH.mkName typs)
+-}

--- a/src/Databrary/Model/Metric/Types.hs
+++ b/src/Databrary/Model/Metric/Types.hs
@@ -15,6 +15,14 @@ import Data.Ord (comparing)
 import qualified Data.Text as T
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift (deriveLiftMany)
+import qualified Data.Typeable.Internal
+import qualified GHC.Arr
+import qualified Database.PostgreSQL.Typed.Types
+import qualified Database.PostgreSQL.Typed.Dynamic
+import qualified Database.PostgreSQL.Typed.Enum
+import qualified Data.Aeson.Types
+import qualified Data.ByteString
+import qualified Data.ByteString.Char8
 
 import Databrary.Has (makeHasRec)
 import Databrary.Model.Enum
@@ -22,8 +30,58 @@ import Databrary.Model.Kind
 import Databrary.Model.Release.Types
 import Databrary.Model.Id.Types
 import Databrary.Model.Category.Types
+import qualified Databrary.Model.Kind
+import qualified Databrary.HTTP.Form.Deform
 
-makeDBEnum "data_type" "MeasureType"
+-- makeDBEnum "data_type" "MeasureType"
+data MeasureType
+  = MeasureTypeText |
+    MeasureTypeNumeric |
+    MeasureTypeDate |
+    MeasureTypeVoid
+  deriving (Eq,
+            Ord,
+            Enum,
+            GHC.Arr.Ix,
+            Bounded,
+            Data.Typeable.Internal.Typeable)
+instance Show MeasureType where
+  show MeasureTypeText = "text"
+  show MeasureTypeNumeric = "numeric"
+  show MeasureTypeDate = "date"
+  show MeasureTypeVoid = "void"
+instance Database.PostgreSQL.Typed.Types.PGType "data_type"
+instance Database.PostgreSQL.Typed.Types.PGParameter "data_type" MeasureType where
+  pgEncode _ MeasureTypeText
+    = BS.pack [116, 101, 120, 116]
+  pgEncode _ MeasureTypeNumeric
+    = BS.pack [110, 117, 109, 101, 114, 105, 99]
+  pgEncode _ MeasureTypeDate
+    = BS.pack [100, 97, 116, 101]
+  pgEncode _ MeasureTypeVoid
+    = BS.pack [118, 111, 105, 100]
+instance Database.PostgreSQL.Typed.Types.PGColumn "data_type" MeasureType where
+  pgDecode _ x_a4zCt
+    = case BS.unpack x_a4zCt of 
+        [116, 101, 120, 116] -> MeasureTypeText
+        [110, 117, 109, 101, 114, 105, 99] -> MeasureTypeNumeric
+        [100, 97, 116, 101] -> MeasureTypeDate
+        [118, 111, 105, 100] -> MeasureTypeVoid
+        _ -> error
+               ("pgDecode data_type: "
+                ++ (Data.ByteString.Char8.unpack x_a4zCt)) 
+instance Database.PostgreSQL.Typed.Dynamic.PGRep "data_type" MeasureType
+instance Database.PostgreSQL.Typed.Enum.PGEnum MeasureType
+instance Kinded MeasureType where
+  kindOf _ = "data_type"
+instance DBEnum MeasureType
+instance Data.Aeson.Types.ToJSON MeasureType where
+  toJSON
+    = (Data.Aeson.Types.toJSON . fromEnum)
+instance Data.Aeson.Types.FromJSON MeasureType where
+  parseJSON = parseJSONEnum
+instance Databrary.HTTP.Form.Deform.Deform f_a4zCu MeasureType where
+  deform = enumForm
 
 type MeasureDatum = BS.ByteString
 

--- a/src/Databrary/Model/Notification/Notice.hs
+++ b/src/Databrary/Model/Notification/Notice.hs
@@ -18,6 +18,12 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Database.PostgreSQL.Typed.Types (PGParameter(..), PGColumn(..))
 import Database.PostgreSQL.Typed.Dynamic (PGRep)
+import qualified Data.Typeable.Internal
+import qualified GHC.Arr
+import qualified Database.PostgreSQL.Typed.Types
+import qualified Database.PostgreSQL.Typed.Enum
+import qualified Data.ByteString
+import qualified Data.ByteString.Char8
 
 import Databrary.HTTP.Form (FormDatum(..))
 import Databrary.HTTP.Form.Deform
@@ -27,7 +33,55 @@ import Databrary.Model.Enum
 import Databrary.Model.Periodic
 import Databrary.Model.Notification.Boot
 
-makeDBEnum "notice_delivery" "Delivery"
+-- makeDBEnum "notice_delivery" "Delivery"
+data Delivery
+  = DeliveryNone |
+    DeliverySite |
+    DeliveryWeekly |
+    DeliveryDaily |
+    DeliveryAsync
+  deriving (Eq,
+            Ord,
+            Enum,
+            GHC.Arr.Ix,
+            Bounded,
+            Data.Typeable.Internal.Typeable)
+instance Show Delivery where
+  show DeliveryNone = "none"
+  show DeliverySite = "site"
+  show DeliveryWeekly = "weekly"
+  show DeliveryDaily = "daily"
+  show DeliveryAsync = "async"
+instance Database.PostgreSQL.Typed.Types.PGType "notice_delivery"
+instance PGParameter "notice_delivery" Delivery where
+  pgEncode _ DeliveryNone = Data.ByteString.pack [110, 111, 110, 101]
+  pgEncode _ DeliverySite = Data.ByteString.pack [115, 105, 116, 101]
+  pgEncode _ DeliveryWeekly
+    = Data.ByteString.pack [119, 101, 101, 107, 108, 121]
+  pgEncode _ DeliveryDaily
+    = Data.ByteString.pack [100, 97, 105, 108, 121]
+  pgEncode _ DeliveryAsync
+    = Data.ByteString.pack [97, 115, 121, 110, 99]
+instance PGColumn "notice_delivery" Delivery where
+  pgDecode _ x_a42l0
+    = case Data.ByteString.unpack x_a42l0 of
+        [110, 111, 110, 101] -> DeliveryNone
+        [115, 105, 116, 101] -> DeliverySite
+        [119, 101, 101, 107, 108, 121] -> DeliveryWeekly
+        [100, 97, 105, 108, 121] -> DeliveryDaily
+        [97, 115, 121, 110, 99] -> DeliveryAsync
+        _ -> error ("pgDecode notice_delivery: " ++ (BSC.unpack x_a42l0))
+instance PGRep "notice_delivery" Delivery
+instance Database.PostgreSQL.Typed.Enum.PGEnum Delivery
+instance Kinded Delivery where
+  kindOf _ = "notice_delivery"
+instance DBEnum Delivery
+instance JSON.ToJSON Delivery where
+  toJSON = (JSON.toJSON . fromEnum)
+instance JSON.FromJSON Delivery where
+  parseJSON = parseJSONEnum
+instance Deform f_a42l1 Delivery where
+  deform = enumForm
 
 fromMaybeDelivery :: Maybe Delivery -> Delivery
 fromMaybeDelivery (Just d) = d

--- a/src/Databrary/Model/Permission/Types.hs
+++ b/src/Databrary/Model/Permission/Types.hs
@@ -8,11 +8,79 @@ module Databrary.Model.Permission.Types
   ) where
 
 import Language.Haskell.TH.Lift (deriveLiftMany)
+import qualified Data.Typeable.Internal
+import qualified GHC.Arr
+import qualified Database.PostgreSQL.Typed.Types
+import qualified Database.PostgreSQL.Typed.Dynamic
+import qualified Database.PostgreSQL.Typed.Enum
+import qualified Data.Aeson.Types
+import qualified Data.ByteString
+import qualified Data.ByteString.Char8
 
 import Databrary.Has (Has(..))
 import Databrary.Model.Enum
+import qualified Databrary.Model.Kind
+import qualified Databrary.HTTP.Form.Deform
 
-makeDBEnum "permission" "Permission"
+-- makeDBEnum "permission" "Permission"
+data Permission
+  = PermissionNONE |
+    PermissionPUBLIC |
+    PermissionSHARED |
+    PermissionREAD |
+    PermissionEDIT |
+    PermissionADMIN
+  deriving (Eq,
+            Ord,
+            Enum,
+            GHC.Arr.Ix,
+            Bounded,
+            Data.Typeable.Internal.Typeable)
+instance Show Permission where
+  show PermissionNONE = "NONE"
+  show PermissionPUBLIC = "PUBLIC"
+  show PermissionSHARED = "SHARED"
+  show PermissionREAD = "READ"
+  show PermissionEDIT = "EDIT"
+  show PermissionADMIN = "ADMIN"
+instance Database.PostgreSQL.Typed.Types.PGType "permission"
+instance Database.PostgreSQL.Typed.Types.PGParameter "permission" Permission where
+  pgEncode _ PermissionNONE
+    = Data.ByteString.pack [78, 79, 78, 69]
+  pgEncode _ PermissionPUBLIC
+    = Data.ByteString.pack [80, 85, 66, 76, 73, 67]
+  pgEncode _ PermissionSHARED
+    = Data.ByteString.pack [83, 72, 65, 82, 69, 68]
+  pgEncode _ PermissionREAD
+    = Data.ByteString.pack [82, 69, 65, 68]
+  pgEncode _ PermissionEDIT
+    = Data.ByteString.pack [69, 68, 73, 84]
+  pgEncode _ PermissionADMIN
+    = Data.ByteString.pack [65, 68, 77, 73, 78]
+instance Database.PostgreSQL.Typed.Types.PGColumn "permission" Permission where
+  pgDecode _ x_a42l2
+    = case Data.ByteString.unpack x_a42l2 of 
+        [78, 79, 78, 69] -> PermissionNONE
+        [80, 85, 66, 76, 73, 67] -> PermissionPUBLIC
+        [83, 72, 65, 82, 69, 68] -> PermissionSHARED
+        [82, 69, 65, 68] -> PermissionREAD
+        [69, 68, 73, 84] -> PermissionEDIT
+        [65, 68, 77, 73, 78] -> PermissionADMIN
+        _ -> error
+               ("pgDecode permission: "
+                ++ (Data.ByteString.Char8.unpack x_a42l2)) 
+instance Database.PostgreSQL.Typed.Dynamic.PGRep "permission" Permission
+instance Database.PostgreSQL.Typed.Enum.PGEnum Permission
+instance Databrary.Model.Kind.Kinded Permission where
+  kindOf _ = "permission"
+instance DBEnum Permission
+instance Data.Aeson.Types.ToJSON Permission where
+  toJSON
+    = (Data.Aeson.Types.toJSON . fromEnum)
+instance Data.Aeson.Types.FromJSON Permission where  -- not used
+  parseJSON = parseJSONEnum
+instance Databrary.HTTP.Form.Deform.Deform f_a42l3 Permission where
+  deform = enumForm
 
 instance Monoid Permission where
   mempty = PermissionNONE

--- a/src/Databrary/Model/Release/Types.hs
+++ b/src/Databrary/Model/Release/Types.hs
@@ -7,11 +7,65 @@ module Databrary.Model.Release.Types
 
 import Data.Foldable (fold)
 import Language.Haskell.TH.Lift (deriveLift)
+import qualified Data.Typeable.Internal
+import qualified GHC.Arr
+import qualified Database.PostgreSQL.Typed.Types
+import qualified Database.PostgreSQL.Typed.Dynamic
+import qualified Database.PostgreSQL.Typed.Enum
+import qualified Data.Aeson.Types
+import qualified Data.ByteString
+import qualified Data.ByteString.Char8
 
 import Databrary.Has (Has(..))
 import Databrary.Model.Enum
+import qualified Databrary.Model.Kind
+import qualified Databrary.HTTP.Form.Deform
 
-makeDBEnum "release" "Release"
+-- makeDBEnum "release" "Release"
+data Release
+    = ReleasePRIVATE | ReleaseSHARED | ReleaseEXCERPTS | ReleasePUBLIC
+          deriving (Eq,
+                    Ord,
+                    Enum,
+                    GHC.Arr.Ix,
+                    Bounded,
+                    Data.Typeable.Internal.Typeable)
+instance Show Release where
+  show ReleasePRIVATE = "PRIVATE"
+  show ReleaseSHARED = "SHARED"
+  show ReleaseEXCERPTS = "EXCERPTS"
+  show ReleasePUBLIC = "PUBLIC"
+instance Database.PostgreSQL.Typed.Types.PGType "release"
+instance Database.PostgreSQL.Typed.Types.PGParameter "release" Release where
+  pgEncode _ ReleasePRIVATE
+    = Data.ByteString.pack [80, 82, 73, 86, 65, 84, 69]
+  pgEncode _ ReleaseSHARED
+    = Data.ByteString.pack [83, 72, 65, 82, 69, 68]
+  pgEncode _ ReleaseEXCERPTS
+    = Data.ByteString.pack [69, 88, 67, 69, 82, 80, 84, 83]
+  pgEncode _ ReleasePUBLIC
+    = Data.ByteString.pack [80, 85, 66, 76, 73, 67]
+instance Database.PostgreSQL.Typed.Types.PGColumn "release" Release where
+  pgDecode _ x_a2Skv
+    = case Data.ByteString.unpack x_a2Skv of
+        [80, 82, 73, 86, 65, 84, 69] -> ReleasePRIVATE
+        [83, 72, 65, 82, 69, 68] -> ReleaseSHARED
+        [69, 88, 67, 69, 82, 80, 84, 83] -> ReleaseEXCERPTS
+        [80, 85, 66, 76, 73, 67] -> ReleasePUBLIC
+        _ -> error
+               ("pgDecode release: " ++ (Data.ByteString.Char8.unpack x_a2Skv))
+instance Database.PostgreSQL.Typed.Dynamic.PGRep "release" Release
+instance Database.PostgreSQL.Typed.Enum.PGEnum Release
+instance Databrary.Model.Kind.Kinded Release where
+  kindOf _ = "release"
+instance DBEnum Release
+instance Data.Aeson.Types.ToJSON Release where
+  toJSON
+    = (Data.Aeson.Types.toJSON . fromEnum)
+instance Data.Aeson.Types.FromJSON Release where
+  parseJSON = parseJSONEnum
+instance Databrary.HTTP.Form.Deform.Deform f_a2Skw Release where
+  deform = enumForm
 
 instance Monoid Release where
   mempty = ReleasePRIVATE


### PR DESCRIPTION
One step closer to no IO / DB connections at compile time.

We can test directly on staging. With all the compile time checks, the chance of anything breaking is close to nothing and rolling back is very easy. 

cc: @chreekat 
