### PR TITLE
Propagate extending the dbconn type to hold mulitple connections

### DIFF
--- a/src/Databrary/Context.hs
+++ b/src/Databrary/Context.hs
@@ -25,7 +25,7 @@ data Context = Context
   { contextService :: !Service
   , contextTimestamp :: !Timestamp
   , contextResourceState :: !InternalState
-  , contextDB :: !DBConn
+  , contextDB :: !DBConn2
   }
 
 makeHasRec ''Context ['contextService, 'contextTimestamp, 'contextResourceState, 'contextDB]


### PR DESCRIPTION
- this is to prepare for adding a second db pool and eventually filling dbconn2 with the conn from second pool

Testing for minimal functioning.

cc: @chreekat 