### PR TITLE
Start using wai-route during transition to Servant

### DIFF
--- a/src/Databrary/Action.hs
+++ b/src/Databrary/Action.hs
@@ -71,7 +71,6 @@ runActionRoute routeMap newRouteMap routeContext req =
             if st == notFound404 -- currently, this might be only possible error result?
             then
                 WAR.route (newRouteMap routeContext) req
-                -- TODO: add not found handler in route map?
             else
                 runAction routeContext (err (st,hdrs)) req
   where

--- a/src/Databrary/Action.hs
+++ b/src/Databrary/Action.hs
@@ -70,25 +70,15 @@ runActionRoute routeMap newRouteMap routeContext req =
         Left (st,hdrs) ->
             if st == notFound404 -- currently, this might be only possible error result?
             then
-                -- match with wai-route
-                --   -- success
-                --   -- error
                 WAR.route (newRouteMap routeContext) req
+                -- TODO: add not found handler in route map?
             else
                 runAction routeContext (err (st,hdrs)) req
-        -- resultingAction :: Action
-        -- resultingAction = either err id eMatchedAction
   where
     err :: (Status, ResponseHeaders) -> Action
     err (status, headers) = withoutAuth $ peeks $ response status headers . htmlNotFound
 
-{-
-newRouteMap :: Service -> [(BS.ByteString, WAR.Handler IO)]
-newRouteMap routeContext =
-    [ ("/robots.txt", (\ps req respond -> runAction routeContext (robotsTxtHandler ps) req respond))
-    ]
-  -}    
-
+-- TODO: delete notes below
 -- route
 --  :: Monad m => [(ByteString, Handler m)] -> Request -> (Response -> m ResponseReceived) -> m ResponseReceived
 {-

--- a/src/Databrary/Action.hs
+++ b/src/Databrary/Action.hs
@@ -23,9 +23,11 @@ module Databrary.Action
   , runActionRoute
   ) where
 
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Lazy as BSL
-import Network.HTTP.Types (Status, seeOther303, forbidden403, notFound404, ResponseHeaders, hLocation)
+import Data.Text (Text)
+import Network.HTTP.Types (Status, seeOther303, forbidden403, notFound404, ResponseHeaders, hLocation, ok200)
 import qualified Network.Wai as Wai
 import qualified Web.Route.Invertible.Wai as R
 import qualified Network.Wai.Route as WAR
@@ -56,13 +58,54 @@ maybeAction :: Maybe a -> ActionM a
 maybeAction (Just a) = return a
 maybeAction Nothing = result =<< peeks notFoundResponse
 
-runActionRoute :: R.RouteMap Action -> Service -> Wai.Application
-runActionRoute routeMap routeContext req =
+runActionRoute
+  :: R.RouteMap Action -> (Service -> [(BS.ByteString, WAR.Handler IO)]) -> Service -> Wai.Application
+runActionRoute routeMap newRouteMap routeContext req =
     let eMatchedAction :: Either (Status, ResponseHeaders) Action
         eMatchedAction = R.routeWai req routeMap
-        resultingAction :: Action
-        resultingAction = either err id eMatchedAction
-    in runAction routeContext resultingAction req
+    in
+      case eMatchedAction of
+        Right act ->
+            runAction routeContext act req
+        Left (st,hdrs) ->
+            if st == notFound404 -- currently, this might be only possible error result?
+            then
+                -- match with wai-route
+                --   -- success
+                --   -- error
+                WAR.route (newRouteMap routeContext) req
+            else
+                runAction routeContext (err (st,hdrs)) req
+        -- resultingAction :: Action
+        -- resultingAction = either err id eMatchedAction
   where
     err :: (Status, ResponseHeaders) -> Action
     err (status, headers) = withoutAuth $ peeks $ response status headers . htmlNotFound
+
+{-
+newRouteMap :: Service -> [(BS.ByteString, WAR.Handler IO)]
+newRouteMap routeContext =
+    [ ("/robots.txt", (\ps req respond -> runAction routeContext (robotsTxtHandler ps) req respond))
+    ]
+  -}    
+
+-- route
+--  :: Monad m => [(ByteString, Handler m)] -> Request -> (Response -> m ResponseReceived) -> m ResponseReceived
+{-
+type Handler m
+= [(ByteString, ByteString)] -- The captured path parameters.
+-> Request -- The matched Request.
+-> (Response -> m ResponseReceived) -- The continuation.
+-> m ResponseReceived
+-}
+
+{-
+type ActionRoute a = R.RouteAction a Action
+
+data Action = Action
+  { _actionAuth :: !Bool
+  , _actionM :: !(ActionM Response)
+  }
+newtype ActionM a = ActionM { unActionM :: ReaderT RequestContext IO a }
+  deriving (Functor, Applicative, Alternative, Monad, MonadPlus, MonadIO, MonadBase IO, MonadThrow, MonadReader RequestContext)
+-}

--- a/src/Databrary/Controller/Root.hs
+++ b/src/Databrary/Controller/Root.hs
@@ -3,6 +3,7 @@ module Databrary.Controller.Root
   ( viewRoot
   , viewConstants
   , viewRobotsTxtHandler
+  , notFoundResponseHandler
   ) where
 
 import Control.Monad (when)
@@ -11,6 +12,7 @@ import qualified Data.ByteString as BS
 import Data.Maybe (isNothing)
 import qualified Data.Text as T
 import Data.Text (Text)
+import Network.HTTP.Types (notFound404)
 
 import Databrary.Has
 import qualified Databrary.JSON as JSON
@@ -20,6 +22,7 @@ import Databrary.Action
 import Databrary.Controller.Angular
 import Databrary.View.Root
 import Databrary.Web.Constants
+import Databrary.View.Error (htmlNotFound)
 
 viewRoot :: ActionRoute API
 viewRoot = action GET pathAPI $ \api -> withAuth $ do
@@ -39,3 +42,6 @@ viewRobotsTxtHandler :: [(BS.ByteString, BS.ByteString)] -> Action
 viewRobotsTxtHandler [] =  -- TODO: ensure GET
     withoutAuth $ return $ okResponse [] ("" :: Text)
     -- NOTE: DEVEL/SANDBOX behavior wasn't copied here
+
+notFoundResponseHandler :: [(BS.ByteString, BS.ByteString)] -> Action
+notFoundResponseHandler _ = withoutAuth $ peeks $ response notFound404 [] . htmlNotFound

--- a/src/Databrary/Controller/Root.hs
+++ b/src/Databrary/Controller/Root.hs
@@ -2,13 +2,15 @@
 module Databrary.Controller.Root
   ( viewRoot
   , viewConstants
-  , viewRobotsTxt
+  , viewRobotsTxtHandler
   ) where
 
 import Control.Monad (when)
 import qualified Data.Aeson.Types as JSON
+import qualified Data.ByteString as BS
 import Data.Maybe (isNothing)
 import qualified Data.Text as T
+import Data.Text (Text)
 
 import Databrary.Has
 import qualified Databrary.JSON as JSON
@@ -31,12 +33,9 @@ viewConstants :: ActionRoute ()
 viewConstants = action GET (pathJSON >/> "constants") $ \() -> withoutAuth $
   return $ okResponse [] $ JSON.objectEncoding constantsJSON
 
-viewRobotsTxt :: ActionRoute ()
-viewRobotsTxt = action GET "robots.txt" $ \() -> withoutAuth $
-  return $ okResponse [] (
-#if defined(DEVEL) || defined(SANDBOX)
-    "User-agent: *\nDisallow: /\n"
-#else
-    ""
-#endif
-    :: T.Text)
+-- NEW HANDLERS 
+
+viewRobotsTxtHandler :: [(BS.ByteString, BS.ByteString)] -> Action
+viewRobotsTxtHandler [] =  -- TODO: ensure GET
+    withoutAuth $ return $ okResponse [] ("" :: Text)
+    -- NOTE: DEVEL/SANDBOX behavior wasn't copied here

--- a/src/Databrary/Main.hs
+++ b/src/Databrary/Main.hs
@@ -16,7 +16,7 @@ import Databrary.Service.Init (withService)
 import Databrary.Context
 import Databrary.Web.Rules (generateWebFiles)
 import Databrary.Action (runActionRoute)
-import Databrary.Routes (routeMap)
+import Databrary.Routes (routeMap, newRouteMap)
 import Databrary.Warp (runWarp)
 import Databrary.EZID.Volume (updateEZID)
 
@@ -70,7 +70,7 @@ main = do
         -- used to run migrations on startup when not in devel mode
         -- should check migrations2 table for last migration against last entry in schema2 dir
         putStrLn "running warp"
-        runWarp conf rc (runActionRoute routes rc)
+        runWarp conf rc (runActionRoute routes newRouteMap rc)
     _ -> do
       mapM_ putStrLn err
       putStrLn $ Opt.usageInfo ("Usage: " ++ prog ++ " [OPTION...]") opts

--- a/src/Databrary/Routes.hs
+++ b/src/Databrary/Routes.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Databrary.Routes
   ( routeMap
+  , newRouteMap
   ) where
 
+import qualified Data.ByteString as BS
 import Web.Route.Invertible (RouteMap, routes, routeCase)
+import qualified Network.Wai.Route as WAR
 
 import Databrary.Action
 import Databrary.Controller.Root
@@ -37,11 +40,20 @@ import Databrary.Controller.Web
 import Databrary.Controller.Search
 import Databrary.Controller.Periodic
 import Databrary.Controller.Notification
+import Databrary.Action.Run (runAction)
+import Databrary.Service.Types (Service)
+
+newRouteMap :: Service -> [(BS.ByteString, WAR.Handler IO)]
+newRouteMap routeContext =
+    [
+      ("/robots.txt", (\ps req respond -> runAction routeContext (viewRobotsTxtHandler ps) req respond))
+      
+    ]
 
 routeMap :: RouteMap Action
 routeMap = routes
   [ route viewRoot
-  , route viewRobotsTxt
+  -- , route viewRobotsTxt
 
   , route viewUser
   , route postUser

--- a/src/Databrary/Routes.hs
+++ b/src/Databrary/Routes.hs
@@ -46,8 +46,15 @@ import Databrary.Service.Types (Service)
 newRouteMap :: Service -> [(BS.ByteString, WAR.Handler IO)]
 newRouteMap routeContext =
     [
-      ("/robots.txt", (\ps req respond -> runAction routeContext (viewRobotsTxtHandler ps) req respond))
-      
+        ("/robots.txt", (\ps req respond -> runAction routeContext (viewRobotsTxtHandler ps) req respond))
+
+        -- hack to override not found
+      , ("/:a", (\ps req respond -> runAction routeContext (notFoundResponseHandler ps) req respond))
+      , ("/:a/:b", (\ps req respond -> runAction routeContext (notFoundResponseHandler ps) req respond))
+      , ("/:a/:b/:c", (\ps req respond -> runAction routeContext (notFoundResponseHandler ps) req respond))
+      , ("/:a/:b/:c/:d", (\ps req respond -> runAction routeContext (notFoundResponseHandler ps) req respond))
+      , ("/:a/:b/:c/:d/:e", (\ps req respond -> runAction routeContext (notFoundResponseHandler ps) req respond))
+      , ("/:a/:b/:c/:d/:e:/:f", (\ps req respond -> runAction routeContext (notFoundResponseHandler ps) req respond))
     ]
 
 routeMap :: RouteMap Action


### PR DESCRIPTION
- attempt new routes when no old route matches
- doesn't differentiate between request method yet (GET, POST, etc)
- uses not found hack

TODO: `WAR.route (newRouteMap routeContext) req` replace this with Servant or Servant Raw.

cc: @chreekat 