### PR TITLE
Two simple helper functions abstracting cassava details + tests

### DIFF
--- a/databrary.cabal
+++ b/databrary.cabal
@@ -34,6 +34,7 @@ library
     Paths_databrary
     Blaze.ByteString.Builder.Html.Word
     Data.ByteString.Builder.Escape
+    Data.Csv.Contrib
     Data.RangeSet.Parse
     Databrary.Warp
     Databrary.Solr.Service
@@ -539,9 +540,12 @@ test-suite databrary-test
     , tasty
     , tasty-expected-failure
     , tasty-hunit
+    , unordered-containers
+    , vector
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   default-language: Haskell2010
   other-modules:
       Databrary.HTTP.Form.DeformTest
-
+    , Data.Csv.ContribTest
+      
 -- vim: shiftwidth=2

--- a/src/Data/Csv/Contrib.hs
+++ b/src/Data/Csv/Contrib.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Data.Csv.Contrib
+  ( getHeaders
+  , extractColumnDefaulting
+  ) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Csv as CSV
+import qualified Data.HashMap.Strict as HMP
+import qualified Data.Vector as V
+import Data.Vector (Vector)
+
+getHeaders :: CSV.Header -> [BS.ByteString]
+getHeaders = V.toList
+
+-- TODO: use in extractSampleColumns
+extractColumnDefaulting :: BS.ByteString -> Vector CSV.NamedRecord -> [BS.ByteString]
+extractColumnDefaulting hdr records =
+   extractColumn hdr records (maybe "" id)
+
+extractColumn :: BS.ByteString -> Vector CSV.NamedRecord -> (Maybe BS.ByteString -> a) -> [a]
+extractColumn hdr records applyDefault =
+   ( V.toList
+   . fmap (\rowMap -> (applyDefault . HMP.lookup hdr) rowMap))
+   records

--- a/test/Data/Csv/ContribTest.hs
+++ b/test/Data/Csv/ContribTest.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+module Data.Csv.ContribTest (tests) where
+
+import qualified Data.HashMap.Strict as HMP
+import qualified Data.Vector as V
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Csv.Contrib
+
+tests :: TestTree
+tests = testGroup "Data.Csv.ContribTest"
+    [ testCase "extractColumnDefaulting"
+        (extractColumnDefaulting "c1" (V.fromList [(HMP.fromList [("c1", "val1")])]) @?= ["val1"])
+    ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Tasty
 import qualified Databrary.HTTP.Form.DeformTest
+import qualified Data.Csv.ContribTest
 
 main :: IO ()
 main = defaultMain tests
@@ -9,4 +10,5 @@ main = defaultMain tests
 tests :: TestTree
 tests = testGroup "databrary"
     [ Databrary.HTTP.Form.DeformTest.tests
+    , Data.Csv.ContribTest.tests
     ]


### PR DESCRIPTION
- getHeaders converts header names from cassava specific type to a more general type
- extractColumnDefaulting gets one column from a list of rows, adding default
to strip Maybe, since Nothing should never occur with known header names

one of many small PRs to come to merge full participant upload feature.