### PR TITLE
Add postgresql-simple pool

### DIFF
--- a/databrary.cabal
+++ b/databrary.cabal
@@ -29,7 +29,7 @@ Flag sandbox
 library
   hs-source-dirs: src
   c-sources: src/Databrary/Store/avFrame.c
-  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  ghc-options: -Wall -Wcompat -Wredundant-constraints
   exposed-modules:
     Paths_databrary
     Blaze.ByteString.Builder.Html.Word
@@ -542,7 +542,7 @@ test-suite databrary-test
     , tasty-hunit
     , unordered-containers
     , vector
-  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  ghc-options: -Wall -Wcompat -Wredundant-constraints
   default-language: Haskell2010
   other-modules:
       Databrary.HTTP.Form.DeformTest

--- a/src/Databrary/Context.hs
+++ b/src/Databrary/Context.hs
@@ -25,7 +25,7 @@ data Context = Context
   { contextService :: !Service
   , contextTimestamp :: !Timestamp
   , contextResourceState :: !InternalState
-  , contextDB :: !DBConn2
+  , contextDB :: !DBConn
   }
 
 makeHasRec ''Context ['contextService, 'contextTimestamp, 'contextResourceState, 'contextDB]

--- a/src/Databrary/Service/DB.hs
+++ b/src/Databrary/Service/DB.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances, FlexibleContexts, MultiParamTypeClasses, ConstraintKinds, DefaultSignatures, GeneralizedNewtypeDeriving, TypeFamilies, OverloadedStrings, StandaloneDeriving #-}
 module Databrary.Service.DB
   ( DBPool
-  , DBConn2
+  , DBConn
   , initDB
   , finiDB
   , withDB
@@ -62,12 +62,7 @@ confPGDatabase conf = defaultPGDatabase
 
 
 newtype DBPool = PGPool (Pool PGConnection)
--- type DBConn = PGConnection
-data DBConn2 =
-    DBConn2 {
-        dbcConnTyped :: PGConnection
-      , dbcConn :: () -- TODO: postgresql-simple conn
-    }
+type DBConn = PGConnection
 
 initDB :: C.Config -> IO DBPool
 initDB conf =
@@ -85,17 +80,16 @@ finiDB :: DBPool -> IO ()
 finiDB (PGPool p) = do
   destroyAllResources p
 
-withDB :: DBPool -> (DBConn2 -> IO a) -> IO a
-withDB (PGPool p) useConn =
-    withResource p (\c -> useConn (DBConn2 c ()))
+withDB :: DBPool -> (DBConn -> IO a) -> IO a
+withDB (PGPool p) = withResource p
 
-type MonadDB c m = (MonadIO m, MonadHas DBConn2 c m)
+type MonadDB c m = (MonadIO m, MonadHas DBConn c m)
 
 {-# INLINE liftDB #-}
-liftDB :: MonadDB c m => (DBConn2 -> IO a) -> m a
+liftDB :: MonadDB c m => (PGConnection -> IO a) -> m a
 liftDB = focusIO
 
-type DBM a = ReaderT DBConn2 IO a
+type DBM a = ReaderT PGConnection IO a
 
 runDBM :: DBPool -> DBM a -> IO a
 runDBM p = withDB p . runReaderT
@@ -108,10 +102,10 @@ dbTryJust :: MonadDB c m => (PGError -> Maybe e) -> DBM a -> m (Either e a)
 dbTryJust err q = liftDB $ tryJust err . runReaderT q
 
 dbRunQuery :: (MonadDB c m, PGQuery q a) => q -> m (Int, [a])
-dbRunQuery q = liftDB $ \c -> pgRunQuery (dbcConnTyped c) q
+dbRunQuery q = liftDB $ \c -> pgRunQuery c q
 
 dbExecute :: (MonadDB c m, PGQuery q ()) => q -> m Int
-dbExecute q = liftDB $ \c -> pgExecute (dbcConnTyped c) q
+dbExecute q = liftDB $ \c -> pgExecute c q
 
 dbExecuteSimple :: MonadDB c m => PGSimpleQuery () -> m Int
 dbExecuteSimple = dbExecute
@@ -130,10 +124,10 @@ dbExecute1' q = do
   unless r $ fail $ "pgExecute1' " ++ show q ++ ": failed"
 
 dbExecute_ :: (MonadDB c m) => BSL.ByteString -> m ()
-dbExecute_ q = liftDB $ \c -> pgSimpleQueries_ (dbcConnTyped c) q
+dbExecute_ q = liftDB $ \c -> pgSimpleQueries_ c q
 
 dbQuery :: (MonadDB c m, PGQuery q a) => q -> m [a]
-dbQuery q = liftDB $ \c -> pgQuery (dbcConnTyped c) q
+dbQuery q = liftDB $ \c -> pgQuery c q
 
 dbQuery1 :: (MonadDB c m, PGQuery q a, Show q) => q -> m (Maybe a)
 dbQuery1 q = do
@@ -147,12 +141,12 @@ dbQuery1' :: (MonadDB c m, PGQuery q a, Show q) => q -> m a
 dbQuery1' q = maybe (fail $ "pgQuery1' " ++ show q ++ ": no results") return =<< dbQuery1 q
 
 dbTransaction :: MonadDB c m => DBM a -> m a
-dbTransaction f = liftDB $ \c -> pgTransaction (dbcConnTyped c) (runReaderT f c)
+dbTransaction f = liftDB $ \c -> pgTransaction c (runReaderT f c)
 
 dbTransaction' :: (MonadBaseControl IO m, MonadDB c m) => m a -> m a
 dbTransaction' f = do
   c <- peek
-  liftBaseOp_ (pgTransaction (dbcConnTyped c)) f
+  liftBaseOp_ (pgTransaction c) f
 
 -- For connections outside runtime:
 
@@ -163,7 +157,7 @@ runDBConnection :: DBM a -> IO a
 runDBConnection f = bracket
   (pgConnect =<< loadPGDatabase)
   pgDisconnect
-  (\c -> runReaderT f (DBConn2 c ()))
+  (runReaderT f)
 
 loadTDB :: TH.DecsQ
 loadTDB = do 
@@ -183,4 +177,4 @@ useTDB = do
 runTDB :: DBM a -> TH.Q a
 runTDB f = do
   _ <- useTDB
-  TH.runIO $ withTPGConnection $ (\c -> runReaderT f (DBConn2 c ()))
+  TH.runIO $ withTPGConnection $ runReaderT f


### PR DESCRIPTION
Rather than a pool of tupled connections, I want a tuple of pools. This does the thing.

Most of the noise is due to reverting the creation of tupled connections. The meat of the change is in initDB. Since all of the website only uses MonadDB / withDB, the change is very quiet otherwise.