### PR TITLE
Provide specialized volume metric lookup for participant metrics

### DIFF
--- a/src/Databrary/Model/Category.hs
+++ b/src/Databrary/Model/Category.hs
@@ -5,6 +5,7 @@ module Databrary.Model.Category
   , getCategory
   , getCategory'
   , categoryJSON
+  , participantCategory
   ) where
 
 import qualified Data.IntMap.Strict as IntMap
@@ -72,3 +73,6 @@ categoryJSON :: JSON.ToObject o => Category -> JSON.Record (Id Category) o
 categoryJSON Category{..} = JSON.Record categoryId $
      "name" JSON..= categoryName
   <> "description" JSON..=? categoryDescription
+
+participantCategory :: Category
+participantCategory = head allCategories

--- a/src/Databrary/Model/Metric.hs
+++ b/src/Databrary/Model/Metric.hs
@@ -4,6 +4,7 @@ module Databrary.Model.Metric
   , allMetrics
   , getMetric
   , getMetric'
+  , participantMetrics
   , metricLong
   , birthdateMetric
   , metricJSON
@@ -699,6 +700,9 @@ getMetric (Id i) = IntMap.lookup (fromIntegral i) metricsById
 
 getMetric' :: Id Metric -> Metric
 getMetric' (Id i) = metricsById IntMap.! fromIntegral i
+
+participantMetrics :: [Metric]
+participantMetrics = filter ((== participantCategory) . metricCategory) allMetrics
 
 -- this is a hack, should be in database
 metricLong :: Metric -> Bool

--- a/src/Databrary/Model/VolumeMetric.hs
+++ b/src/Databrary/Model/VolumeMetric.hs
@@ -17,6 +17,7 @@ import qualified Database.PostgreSQL.Typed.Query
 import qualified Database.PostgreSQL.Typed.Types
 import qualified Data.ByteString
 import Data.ByteString (ByteString)
+import qualified Data.List as L
 import qualified Data.String
 
 import Databrary.Service.DB
@@ -30,6 +31,12 @@ import Databrary.Model.VolumeMetric.SQL
 lookupVolumeMetrics :: (MonadDB c m) => Volume -> m [Id Metric]
 lookupVolumeMetrics v =
   dbQuery $(selectQuery selectVolumeMetric "$WHERE volume = ${volumeId $ volumeRow v} ORDER BY metric")
+
+lookupVolumeParticipantMetrics :: (MonadDB c m) => Volume -> m [Metric]
+lookupVolumeParticipantMetrics vol = do
+    volumeActiveMetricIds <- lookupVolumeMetrics vol
+    -- liftIO (print ("metric ids", metricIds))
+    pure ((fmap getMetric' volumeActiveMetricIds) `L.intersect` participantMetrics)
 
 mapQuery :: ByteString -> ([PGValue] -> a) -> PGSimpleQuery a
 mapQuery qry mkResult =
@@ -133,4 +140,3 @@ removeVolumeCategory v c = do
                           _p_a6Gu2]))
         (volumeId $ volumeRow v) c)
             (\[] -> ()))
-


### PR DESCRIPTION
- moving towards each "category" having specific functions instead of generic system,
start by exposing a function that provides active metrics used for a volume's participants
- this function is in preparation for csv upload parsing that will compare defined metrics
against csv fields detected

(This is slightly speculative, but the code using it should be merged tomorrow. Will change workflow once we come up with a new approach.)