### PR TITLE
Pin nixpkgs for node-default

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
-{ nodePackages ? import ./node-default.nix {}
-, databraryRoot ? ./.
+{ databraryRoot ? ./.
 }:
 
 let
@@ -12,6 +11,7 @@ let
   }) {};
   # Definition of nixpkgs, version controlled by Reflex-FRP
   nixpkgs = reflex-platform.nixpkgs;
+  nodePackages = import ./node-default.nix { pkgs = nixpkgs; };
   inherit (nixpkgs) fetchFromGitHub writeScriptBin cpio wget;
   # nixpkgs functions used to regulate Haskell overrides
   inherit (nixpkgs.haskell.lib) dontCheck overrideCabal doJailbreak;


### PR DESCRIPTION
- have node-default use the same nixpkgs version as all other aspects of build
- this is needed for new installations of nix, where the latest version of nix pkgs no longer contains node 4.
`error: attribute 'nodejs-4_x' missing, at /home/webdev/dev/databrary/node-default.nix:5:48`