### PR TITLE
Repair config for mailtrap, they now require smtp subdomain

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,7 @@ let
       mkdir databrary_logs
       touch databrary_logs/solr_log
     fi
+    rm -f config/email # temporary to cleanup cached old file
     if [ ! -e "config/email" ]; then
       cp install/config.email config/email
     fi

--- a/install/config.email
+++ b/install/config.email
@@ -1,1 +1,1 @@
-["mailtrap.io",2525,"cde4b4ec8a0826","6db0925a0de62c"]
+["smtp.mailtrap.io",2525,"cde4b4ec8a0826","6db0925a0de62c"]


### PR DESCRIPTION
- mail delivery wasn't working for development
- it works now