### PR TITLE
Stop hard clean of all ghci artifacts, formerly needed when switching…

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
     if [ ! -e "config/email" ]; then
       cp install/config.email config/email
     fi
-    rm -rf dist
+    # rm -rf dist   # add this back when changing ffmpeg versions, c artifacts don't regenerate properly
     cabal configure --datadir=. --datasubdir=.
     cabal repl lib:databrary
   '';


### PR DESCRIPTION
… ffmpeg versions

- ffmpeg relies on c and haskell-c code and something generated from that stays around
when switching ffmpeg version used in nix definition
- since we were only changing ffmpeg versions during initial development, don't
perform this expensive rebuild every time; re-enable this in the future when ffmpeg is changed