### PR TITLE
First integration test, disorganized

### DIFF
--- a/databrary.cabal
+++ b/databrary.cabal
@@ -595,4 +595,26 @@ test-suite discovered
     , Data.Csv.ContribTest
     , Data.RangeSet.ParseTest
 
+test-suite inttest-placeholder
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: pkgs/databrary-inttest
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , containers
+    , http-conduit
+    , http-types
+    , tasty
+    , tasty-discover
+    , tasty-expected-failure
+    , tasty-hunit
+    , transformers
+    , text
+    , time
+    , unordered-containers
+    , vector
+  default-language: Haskell2010
+
 -- vim: shiftwidth=2

--- a/databrary.nix
+++ b/databrary.nix
@@ -3,7 +3,7 @@
 , case-insensitive, cassava, conduit-combinators, containers, cookie, cracklib
 , cryptonite, data-default-class, directory, fast-logger, ffmpeg
 , filepath, hashable, hjsonschema, http-client, http-client-tls
-, http-types, invertible
+, http-conduit, http-types, invertible
 , lifted-base, memory, mime-mail, mime-types, monad-control, mtl
 , network, network-uri, openssl, parsec, path, path-io, posix-paths
 , postgresql-simple, postgresql-typed, process, range-set-list
@@ -80,7 +80,7 @@ in
     ffmpeg
   ];
   testHaskellDepends = [
-    attoparsec base range-set-list tasty tasty-discover tasty-expected-failure
+    attoparsec base http-conduit range-set-list tasty tasty-discover tasty-expected-failure
     tasty-hunit http-types
   ];
   executableToolDepends = [

--- a/pkgs/databrary-inttest/Main.hs
+++ b/pkgs/databrary-inttest/Main.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = pure ()

--- a/runtime-dirs/databrary-inttest/controllers/root/robotstxt/checkresult.hs
+++ b/runtime-dirs/databrary-inttest/controllers/root/robotstxt/checkresult.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Test.Tasty
+import Test.Tasty.HUnit
+import qualified Data.ByteString.Lazy.Char8 as BLC
+
+main :: IO ()
+main = do
+    bdy <- BLC.getContents
+    runCheck bdy
+
+runCheck :: BLC.ByteString -> Assertion
+runCheck bdy =
+    BLC.all (`elem` [' ', '\n']) bdy @? "expected empty robots.txt"

--- a/runtime-dirs/databrary-inttest/controllers/root/robotstxt/fetchresult.hs
+++ b/runtime-dirs/databrary-inttest/controllers/root/robotstxt/fetchresult.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- dependencies come implicitly from databary's haskell build-depends...
+
+import Network.HTTP.Simple
+import qualified Data.ByteString.Lazy.Char8 as BLC
+
+main :: IO ()
+main = do
+    resp <- httpLBS "http://localhost:8000/robots.txt"
+    BLC.putStrLn (getResponseBody resp)

--- a/runtime-dirs/databrary-inttest/controllers/root/robotstxt/runtest.sh
+++ b/runtime-dirs/databrary-inttest/controllers/root/robotstxt/runtest.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+git_root_dir=$(git rev-parse --show-toplevel)
+nix-shell --attr databrary-dev.env $git_root_dir/default.nix --command "runghc fetchresult.hs | runghc checkresult.hs"


### PR DESCRIPTION
~~Let's criticize this and come up with a few short cleanup steps.~~ Below is one test. We'd have some wrapper loop or even simple a long shell script to invoke each test.

```
# some TBD cleanup/reset
$ runtime-dirs/databrary-inttest/inttest-start-db.sh   #maybe create a simple process group somehow?
$ runtime-dirs/databrary-inttest/inttest-start-backend.sh
$ cd runtime-dirs/databrary-inttest/controllers/root/robotstxt/ && ./runtest.sh
# shutdown db, backend
# return exit code
```

Note: fetchresult.hs is meant to output the result in some standard format soon, so that we could interchangeably use curl or wget if desired for some tests.

~~I'll merge this after that initial cleanup.~~

~~After that, we can use this as something to critique into what we actually want. Do we prefer:~~

~~* like this? ("unix philosophy-ish" - this code is dedicated to Dan, a die-harder unix philosophy man)~~
   ~~* if so, move more source files into pkgs/databrary-inttest?~~
~~* bats?~~
~~* use more shell instead of haskell?~~
~~* combine fetch and check scripts?~~
~~* go all out haskell with database, app startup, and full tasty test suite~~
   ~~* if so, compiled?~~
~~* systemd instead of just shell?~~
