### PR TITLE
Very detailed documenting of cascading Party permission logic on load of party

### DIFF
--- a/src/Databrary/Action/Run.hs
+++ b/src/Databrary/Action/Run.hs
@@ -94,7 +94,7 @@ runAction service (Action needsAuth act) waiReq waiSend
           logAccess
               ts
               waiReq
-              (foldIdentity
+              (extractFromIdentifiedSessOrDefault
                   Nothing
                   (Just . (show :: Id Party -> String) . view)
                   identityUsed

--- a/src/Databrary/Model/Identity.hs
+++ b/src/Databrary/Model/Identity.hs
@@ -32,7 +32,7 @@ determineIdentity =
   maybe NotLoggedIn Identified <$> (flatMapM lookupSession =<< getSignedCookie "session")
 
 maybeIdentity :: (MonadHasIdentity c m) => m a -> (Session -> m a) -> m a
-maybeIdentity u i = foldIdentity u i =<< peek
+maybeIdentity u i = extractFromIdentifiedSessOrDefault u i =<< peek
 
 identityJSON :: JSON.ToObject o => Identity -> JSON.Record (Id Party) o
 identityJSON i = partyJSON (view i) `JSON.foldObjectIntoRec`

--- a/src/Databrary/Model/Identity/Types.hs
+++ b/src/Databrary/Model/Identity/Types.hs
@@ -2,7 +2,7 @@
 module Databrary.Model.Identity.Types
   ( Identity(..)
   , MonadHasIdentity
-  , foldIdentity
+  , extractFromIdentifiedSessOrDefault
   , identityVerf
   , identityAdmin
   , identitySuperuser
@@ -55,13 +55,13 @@ instance Has Access Identity where
 type MonadHasIdentity c m = (MonadHas Identity c m, Has SiteAuth c, Has Party c, Has (Id Party) c, Has Access c)
 
 -- | Extract a value from part of a session for Identified, otherwise use the default value
-foldIdentity :: a -> (Session -> a) -> Identity -> a
-foldIdentity _ extractor (Identified sess) = extractor sess
-foldIdentity defaultVal _ _ = defaultVal
+extractFromIdentifiedSessOrDefault :: a -> (Session -> a) -> Identity -> a
+extractFromIdentifiedSessOrDefault _ extractor (Identified sess) = extractor sess
+extractFromIdentifiedSessOrDefault defaultVal _ _ = defaultVal
 
 -- | Extract the secure token for state changing action, only available for logged in session identity
 identityVerf :: Identity -> Maybe BS.ByteString
-identityVerf = foldIdentity Nothing (Just . sessionVerf)
+identityVerf = extractFromIdentifiedSessOrDefault Nothing (Just . sessionVerf)
 
 identitySuperuserFor :: (Access -> Permission) -> Identity -> Bool
 identitySuperuserFor f (Identified t) = sessionSuperuser t && f (view t) == PermissionADMIN

--- a/src/Databrary/View/Form.hs
+++ b/src/Databrary/View/Form.hs
@@ -150,7 +150,8 @@ inputHidden val ref dat = H.input
   H.! HA.value (maybe (H.toValue val) byteStringValue dat)
 
 csrfForm :: RequestContext -> FormHtml f
-csrfForm = lift . foldIdentity mempty (\s -> inputHidden (byteStringValue $ sessionVerf s) "csverf" Nothing) . view
+csrfForm =
+    lift . extractFromIdentifiedSessOrDefault mempty (\s -> inputHidden (byteStringValue $ sessionVerf s) "csverf" Nothing) . view
 
 htmlForm :: T.Text -> ActionRoute a -> a -> FormHtml f -> (JSOpt -> H.Html) -> RequestContext -> FormHtml f
 htmlForm title act arg form body req = liftWith $ \run -> do

--- a/src/Databrary/View/Root.hs
+++ b/src/Databrary/View/Root.hs
@@ -22,7 +22,7 @@ import Databrary.View.Html
 htmlRoot :: RequestContext -> H.Html
 htmlRoot req = htmlTemplate req Nothing $ \js -> do
   H.ul $ do
-    H.li $ foldIdentity
+    H.li $ extractFromIdentifiedSessOrDefault
       (H.a H.! actionLink viewLogin () js $ "login")
       (\_ -> H.a H.! actionLink viewParty (HTML, TargetProfile) js $ "profile")
       (view req)

--- a/src/Databrary/View/Template.hs
+++ b/src/Databrary/View/Template.hs
@@ -146,7 +146,7 @@ htmlTemplate req title body = H.docTypeHtml $ do
                       H.string l
               H.ul
                 H.! HA.class_ "toolbar-user inline-block flat cf"
-                $ foldIdentity
+                $ extractFromIdentifiedSessOrDefault
                   (H.li $ H.a H.! actionLink viewLogin () hasjs $ "Login")
                   (\_ -> do
                     H.li $ H.a H.! actionLink viewParty (HTML, TargetProfile) hasjs $ "Your Dashboard"

--- a/test/Databrary/Model/Identity/TypesTest.hs
+++ b/test/Databrary/Model/Identity/TypesTest.hs
@@ -10,17 +10,17 @@ import Databrary.Model.Identity.Types
 import Databrary.Model.Party.TypesTest
 -- import Databrary.Model.Token.TypesTest
 
-unit_foldIdentity :: Assertion
-unit_foldIdentity = do
+unit_extractFromIdentifiedSessOrDefault :: Assertion
+unit_extractFromIdentifiedSessOrDefault = do
     -- example
-    runFoldIdentity NotLoggedIn @?= Default
+    runExtractFromIdentifiedSessOrDefault NotLoggedIn @?= Default
     -- typical
-    runFoldIdentity IdentityNotNeeded @?= Default
-    runFoldIdentity (ReIdentified undefined) @?= Default
-    runFoldIdentity (Identified undefined) @?= Extracted
+    runExtractFromIdentifiedSessOrDefault IdentityNotNeeded @?= Default
+    runExtractFromIdentifiedSessOrDefault (ReIdentified undefined) @?= Default
+    runExtractFromIdentifiedSessOrDefault (Identified undefined) @?= Extracted
 
-runFoldIdentity :: Identity -> Result
-runFoldIdentity = foldIdentity Default (const Extracted)
+runExtractFromIdentifiedSessOrDefault :: Identity -> Result
+runExtractFromIdentifiedSessOrDefault = extractFromIdentifiedSessOrDefault Default (const Extracted)
 
 data Result = Default | Extracted deriving (Eq, Show)
 


### PR DESCRIPTION
This mostly makes sense to me, but will probably only be easy to understand a few months from now if we have a wall of example style unit tests, enumerating all the typical possibilities.

The only thing slightly cumbersome about writing example tests or factoring out logic for testing this function is the recursive reference to `p`.

I would be shocked if there was no subtle bug within this coalescing logic, but probably an unimportant bug.

cc: @chreekat