### PR TITLE
Change lookupAuthorize to conditionally retrieve inactive entries

### DIFF
--- a/src/Databrary/Controller/Authorize.hs
+++ b/src/Databrary/Controller/Authorize.hs
@@ -157,7 +157,7 @@ postAuthorize = action POST (pathAPI </>> pathPartyTarget </> pathAuthorizeTarge
 -- Also, build an authorization request or present the current authorization value.
 findOrMakeRequest :: (MonadDB c m) => Party -> Party -> m (Maybe Authorize, Authorize)
 findOrMakeRequest child parent = do
-  c <- lookupAuthorize child parent
+  c <- lookupAuthorize ForPartyViewer child parent -- TODO: should this conditionally use ForPartyAdmin based on permissionParty?
   pure (c, mkAuthorizeRequest child parent `fromMaybe` c)
 
 -- | If present, delete either a prior request for authorization. The authorization to delete can be specified
@@ -170,7 +170,7 @@ deleteAuthorize = action DELETE (pathAPI </>> pathPartyTarget </> pathAuthorizeT
       mAuthorizeTargetParty <- lookupParty oi
       maybeAction mAuthorizeTargetParty
   let (child, parent) = if apply then (p, o) else (o, p)
-  mAuth <- lookupAuthorize child parent
+  mAuth <- lookupAuthorize ForPartyAdmin child parent
   removeAuthorizeNotify mAuth
   case api of
     JSON -> return $ okResponse [] $ JSON.pairs $ "party" JSON..=: partyJSON o

--- a/src/Databrary/Controller/Authorize.hs
+++ b/src/Databrary/Controller/Authorize.hs
@@ -157,7 +157,7 @@ postAuthorize = action POST (pathAPI </>> pathPartyTarget </> pathAuthorizeTarge
 -- Also, build an authorization request or present the current authorization value.
 findOrMakeRequest :: (MonadDB c m) => Party -> Party -> m (Maybe Authorize, Authorize)
 findOrMakeRequest child parent = do
-  c <- lookupAuthorize ForPartyViewer child parent -- TODO: should this conditionally use ForPartyAdmin based on permissionParty?
+  c <- lookupAuthorize ActiveAuthorizations child parent -- TODO: conditionally use ActiveAuth based on permissionParty?
   pure (c, mkAuthorizeRequest child parent `fromMaybe` c)
 
 -- | If present, delete either a prior request for authorization. The authorization to delete can be specified
@@ -170,7 +170,7 @@ deleteAuthorize = action DELETE (pathAPI </>> pathPartyTarget </> pathAuthorizeT
       mAuthorizeTargetParty <- lookupParty oi
       maybeAction mAuthorizeTargetParty
   let (child, parent) = if apply then (p, o) else (o, p)
-  mAuth <- lookupAuthorize ForPartyAdmin child parent
+  mAuth <- lookupAuthorize AllAuthorizations child parent
   removeAuthorizeNotify mAuth
   case api of
     JSON -> return $ okResponse [] $ JSON.pairs $ "party" JSON..=: partyJSON o

--- a/src/Databrary/Model/Authorize.hs
+++ b/src/Databrary/Model/Authorize.hs
@@ -4,6 +4,7 @@ module Databrary.Model.Authorize
   , selfAuthorize
   , lookupAuthorizedChildren
   , lookupAuthorizedParents
+  , AuthorizeFilter(..)
   , lookupAuthorize
   , lookupAuthorizeParent
   , lookupAuthorization
@@ -38,18 +39,21 @@ selfAuthorize :: Party -> Authorize
 selfAuthorize p =
   Authorize (Authorization (if partyId (partyRow p) == partyId (partyRow nobodyParty) then minBound else maxBound) p p) Nothing
 
--- | Get all active authorizations that the child party has been approved from parent parties. Use any permission
--- provided as a lower bounds for parent party authorizations to retrieve.
+-- | Get authorizations where the given party is the child. When the permission argument has a value,
+-- then only provide active, approved authorizations, filtering out authorizations lower than the
+-- provided level.
 lookupAuthorizedParents :: (MonadDB c m, MonadHasIdentity c m) => Party -> Maybe Permission -> m [Authorize]
 lookupAuthorizedParents child perm = do
+  -- TODO: specialize the argument to be AuthorizeFilter for this and Children function below
   ident <- peek
   dbQuery $ maybe
     $(selectQuery (selectAuthorizeParent 'child 'ident) "$")
     (\p -> $(selectQuery (selectAuthorizeParent 'child 'ident) "$WHERE (expires IS NULL OR expires > CURRENT_TIMESTAMP) AND site >= ${p} AND member >= ${p} AND (site <> 'NONE' OR member <> 'NONE')"))
     perm
 
--- | Get all active authorizations that the parent party has granted to child parties. Use any permission
--- provided as a lower bounds for child party authorizations to retrieve.
+-- | Get authorizations where the given party is the parent. When the permission argument has a value,
+-- then only provide active, approved authorizations, filtering out authorizations lower than the
+-- provided level.
 lookupAuthorizedChildren :: (MonadDB c m, MonadHasIdentity c m) => Party -> Maybe Permission -> m [Authorize]
 lookupAuthorizedChildren parent perm = do
   ident <- peek
@@ -58,16 +62,24 @@ lookupAuthorizedChildren parent perm = do
     (\p -> $(selectQuery (selectAuthorizeChild 'parent 'ident) "$WHERE (expires IS NULL OR expires > CURRENT_TIMESTAMP) AND site >= ${p} AND member >= ${p} AND (site <> 'NONE' OR member <> 'NONE')"))
     perm
 
+data AuthorizeFilter = ForPartyAdmin | ForPartyViewer deriving (Eq, Show)
+
 -- | Attempt to find an authorization request or grant from the child party to the granting parent party.
 -- Exclude expired authorizations.
-lookupAuthorize :: MonadDB c m => Party -> Party -> m (Maybe Authorize)
-lookupAuthorize child parent =
+lookupAuthorize :: MonadDB c m => AuthorizeFilter -> Party -> Party -> m (Maybe Authorize)
+lookupAuthorize aFilter child parent =
   dbQuery1 $
       (\mkAuthorize' -> mkAuthorize' child parent)
-          <$> $(selectQuery
-                    authorizeRow
-                    -- only include authorizations that either have no expiration or have not expired yet
-                    "$WHERE authorize.child = ${partyId $ partyRow child} AND authorize.parent = ${partyId $ partyRow parent} AND (expires IS NULL OR expires > CURRENT_TIMESTAMP)")
+          <$> case aFilter of
+                  ForPartyViewer ->
+                      -- only include authorizations that either have no expiration or have not expired yet
+                      $(selectQuery
+                            authorizeRow
+                            "$WHERE authorize.child = ${partyId $ partyRow child} AND authorize.parent = ${partyId $ partyRow parent} AND (expires IS NULL OR expires > CURRENT_TIMESTAMP)")
+                  ForPartyAdmin ->
+                      $(selectQuery
+                            authorizeRow
+                            "$WHERE authorize.child = ${partyId $ partyRow child} AND authorize.parent = ${partyId $ partyRow parent}")
 
 -- | Find an active authorization request or approval from child to parent.
 lookupAuthorizeParent :: (MonadDB c m, MonadHasIdentity c m) => Party -> Id Party -> m (Maybe Authorize)

--- a/src/Databrary/Model/Authorize.hs
+++ b/src/Databrary/Model/Authorize.hs
@@ -62,7 +62,8 @@ lookupAuthorizedChildren parent perm = do
     (\p -> $(selectQuery (selectAuthorizeChild 'parent 'ident) "$WHERE (expires IS NULL OR expires > CURRENT_TIMESTAMP) AND site >= ${p} AND member >= ${p} AND (site <> 'NONE' OR member <> 'NONE')"))
     perm
 
-data AuthorizeFilter = ForPartyAdmin | ForPartyViewer deriving (Eq, Show)
+-- TODO: add combinators above expressing why the filters are being used, probably in authorize controller
+data AuthorizeFilter = AllAuthorizations | ActiveAuthorizations deriving (Eq, Show)
 
 -- | Attempt to find an authorization request or grant from the child party to the granting parent party.
 -- If authorize filter is ForPartyViewer, filter out expired authorizations.
@@ -71,11 +72,11 @@ lookupAuthorize aFilter child parent =
   dbQuery1 $
       (\mkAuthorize' -> mkAuthorize' child parent)
           <$> case aFilter of
-                  ForPartyViewer ->
+                  ActiveAuthorizations ->
                       $(selectQuery
                             authorizeRow
                             "$WHERE authorize.child = ${partyId $ partyRow child} AND authorize.parent = ${partyId $ partyRow parent} AND (expires IS NULL OR expires > CURRENT_TIMESTAMP)")
-                  ForPartyAdmin ->
+                  AllAuthorizations ->
                       $(selectQuery
                             authorizeRow
                             "$WHERE authorize.child = ${partyId $ partyRow child} AND authorize.parent = ${partyId $ partyRow parent}")

--- a/src/Databrary/Model/Authorize.hs
+++ b/src/Databrary/Model/Authorize.hs
@@ -65,14 +65,13 @@ lookupAuthorizedChildren parent perm = do
 data AuthorizeFilter = ForPartyAdmin | ForPartyViewer deriving (Eq, Show)
 
 -- | Attempt to find an authorization request or grant from the child party to the granting parent party.
--- Exclude expired authorizations.
+-- If authorize filter is ForPartyViewer, filter out expired authorizations.
 lookupAuthorize :: MonadDB c m => AuthorizeFilter -> Party -> Party -> m (Maybe Authorize)
 lookupAuthorize aFilter child parent =
   dbQuery1 $
       (\mkAuthorize' -> mkAuthorize' child parent)
           <$> case aFilter of
                   ForPartyViewer ->
-                      -- only include authorizations that either have no expiration or have not expired yet
                       $(selectQuery
                             authorizeRow
                             "$WHERE authorize.child = ${partyId $ partyRow child} AND authorize.parent = ${partyId $ partyRow parent} AND (expires IS NULL OR expires > CURRENT_TIMESTAMP)")

--- a/src/Databrary/Model/Party/Types.hs
+++ b/src/Databrary/Model/Party/Types.hs
@@ -65,8 +65,6 @@ instance Has (Id Party) Account where
 instance Has Access Party where
   view Party{ partyAccess = Just a } = a
   view _ = mempty
--- instance Has Permission Party where
---   view = partyPermission
 
 instance Kinded Party where
   kindOf _ = "party"

--- a/src/Databrary/Model/Party/Types.hs
+++ b/src/Databrary/Model/Party/Types.hs
@@ -65,8 +65,8 @@ instance Has (Id Party) Account where
 instance Has Access Party where
   view Party{ partyAccess = Just a } = a
   view _ = mempty
-instance Has Permission Party where
-  view = partyPermission
+-- instance Has Permission Party where
+--   view = partyPermission
 
 instance Kinded Party where
   kindOf _ = "party"

--- a/src/Databrary/View/Party.hs
+++ b/src/Databrary/View/Party.hs
@@ -43,7 +43,7 @@ htmlPartyView :: Party -> RequestContext -> H.Html
 htmlPartyView p@Party{ partyRow = pr@PartyRow{..}, ..} req = htmlTemplate req Nothing $ \js -> do
   H.div H.! H.customAttribute "typeof" "person" $ do
     H.h1 H.! H.customAttribute "property" "name" $ H.text $ partyName pr
-    when (view p >= PermissionEDIT) $
+    when (partyPermission >= PermissionEDIT) $
       H.p $
         H.a H.! actionLink viewPartyEdit (TargetParty partyId) js $ "edit"
     H.img


### PR DESCRIPTION
There is a bug where an authorized investigator attempts to delete an expired authorization, but the deletion doesn't actually take effect. The problem was the deletion was relying on a lookupAuthorize to find the record to delete, but lookupAuthorize was implemented to only retrieve active authorizations.

Now, lookupAuthorize will conditionally include all authorizations when searching for a match, and deleteAuthorize route uses this enhanced functionality.