### PR TITLE
Remove lots of minor dead code, refactor solr context

### DIFF
--- a/src/Context.hs
+++ b/src/Context.hs
@@ -7,6 +7,9 @@ module Context
   , BackgroundContext(..)
   , BackgroundContextM
   , withBackgroundContextM
+  , SolrIndexingContext(..)
+  , SolrIndexingContextM
+  , mkSolrIndexingContext
   ) where
 
 import Control.Monad.Trans.Reader (ReaderT(..), withReaderT)
@@ -119,3 +122,47 @@ type BackgroundContextM a = ReaderT BackgroundContext IO a
 
 withBackgroundContextM :: BackgroundContextM a -> ActionContextM a
 withBackgroundContextM = withReaderT BackgroundContext
+
+-- | A ActionContext with no Identity, for running Solr indexing.
+data SolrIndexingContext = SolrIndexingContext
+  { slcTimestamp :: !Timestamp
+  , slcLogs :: !Logs
+  , slcHTTPClient :: !HTTPClient
+  , slcSolr :: !Solr
+  , slcDB :: !DBConn -- ^ The specific connection chosen for the running action?
+  }
+
+instance Has Solr SolrIndexingContext where
+  view = slcSolr
+instance Has Logs SolrIndexingContext where
+  view = slcLogs
+instance Has HTTPClient SolrIndexingContext where
+  view = slcHTTPClient
+instance Has DBConn SolrIndexingContext where
+  view = slcDB
+
+instance Has Timestamp SolrIndexingContext where
+  view = slcTimestamp
+instance Has Identity SolrIndexingContext where
+  view _ = IdentityNotNeeded
+instance Has SiteAuth SolrIndexingContext where
+  view _ = view IdentityNotNeeded
+instance Has Party SolrIndexingContext where
+  view _ = view IdentityNotNeeded
+instance Has (Id Party) SolrIndexingContext where
+  view _ = view IdentityNotNeeded
+instance Has Access SolrIndexingContext where
+  view _ = view IdentityNotNeeded
+
+type SolrIndexingContextM a = ReaderT SolrIndexingContext IO a
+
+-- | Build a simpler SolrIndexingContext from a complete ActionContext
+mkSolrIndexingContext :: ActionContext -> SolrIndexingContext
+mkSolrIndexingContext ac =
+    SolrIndexingContext {
+          slcTimestamp = contextTimestamp ac
+        , slcLogs = (serviceLogs . contextService) ac
+        , slcHTTPClient = (serviceHTTPClient . contextService) ac
+        , slcSolr = (serviceSolr . contextService) ac
+        , slcDB = contextDB ac
+    }

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -125,8 +125,7 @@ withBackgroundContextM = withReaderT BackgroundContext
 
 -- | A ActionContext with no Identity, for running Solr indexing.
 data SolrIndexingContext = SolrIndexingContext
-  { slcTimestamp :: !Timestamp
-  , slcLogs :: !Logs
+  { slcLogs :: !Logs
   , slcHTTPClient :: !HTTPClient
   , slcSolr :: !Solr
   , slcDB :: !DBConn -- ^ The specific connection chosen for the running action?
@@ -141,8 +140,6 @@ instance Has HTTPClient SolrIndexingContext where
 instance Has DBConn SolrIndexingContext where
   view = slcDB
 
-instance Has Timestamp SolrIndexingContext where
-  view = slcTimestamp
 instance Has Identity SolrIndexingContext where
   view _ = IdentityNotNeeded
 instance Has SiteAuth SolrIndexingContext where
@@ -160,8 +157,7 @@ type SolrIndexingContextM a = ReaderT SolrIndexingContext IO a
 mkSolrIndexingContext :: ActionContext -> SolrIndexingContext
 mkSolrIndexingContext ac =
     SolrIndexingContext {
-          slcTimestamp = contextTimestamp ac
-        , slcLogs = (serviceLogs . contextService) ac
+          slcLogs = (serviceLogs . contextService) ac
         , slcHTTPClient = (serviceHTTPClient . contextService) ac
         , slcSolr = (serviceSolr . contextService) ac
         , slcDB = contextDB ac

--- a/src/Controller/CSV.hs
+++ b/src/Controller/CSV.hs
@@ -12,6 +12,7 @@ import Data.Foldable (fold)
 import Data.Function (on)
 import Data.List (foldl', nubBy, groupBy)
 import Data.Monoid ((<>))
+import Data.Ord (comparing)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Network.HTTP.Types (hContentType)
@@ -58,7 +59,7 @@ tenc = TE.encodeUtf8
 updateHeaders :: [(Category, Int)] -> Records -> [(Category, Int)]
 updateHeaders h [] = h
 updateHeaders [] l = map (\rl@(r:_) -> (recordCategory $ recordRow r, length rl)) l
-updateHeaders hl@(cm@(c,m):hl') rll@(~rl@(r:_):rll') = case compare c rc of
+updateHeaders hl@(cm@(c,m):hl') rll@(~rl@(r:_):rll') = case comparing categoryId c rc of
   LT -> cm                     : updateHeaders hl' rll
   EQ -> (c, m `max` length rl) : updateHeaders hl' rll'
   GT -> (rc, length rl)        : updateHeaders hl rll'
@@ -91,7 +92,7 @@ recordsRow h [] = concatMap (`metricsRow` []) h
 recordsRow ~(h:hl) (r:rl) = metricsRow h (recordMeasures r) ++ recordsRow hl rl
 
 dataRow :: Headers -> Records -> [BS.ByteString]
-dataRow hl@((c,m):hl') rll@(~rl@(r:_):rll') = case compare c rc of
+dataRow hl@((c,m):hl') rll@(~rl@(r:_):rll') = case comparing categoryId c rc of
   LT -> recordsRow m [] ++ dataRow hl' rll
   EQ -> recordsRow m rl ++ dataRow hl' rll'
   GT -> dataRow hl rll'

--- a/src/Controller/Comment.hs
+++ b/src/Controller/Comment.hs
@@ -8,7 +8,7 @@ import Control.Monad.Trans.Class (lift)
 import Data.Function (on)
 
 import Ops
-import Has
+-- import Has
 import qualified JSON as JSON
 import Model.Permission
 import Model.Id

--- a/src/Controller/Comment.hs
+++ b/src/Controller/Comment.hs
@@ -44,14 +44,14 @@ postComment = action POST (pathJSON >/> pathSlotId </< "comment") $ \si -> withA
   top <- containerIsVolumeTop (slotContainer s)
   forM_ p $ \r -> when (on (/=) (partyId . partyRow . accountParty) (commentWho r) u) $
     createNotification (blankNotification (commentWho r) NoticeCommentReply)
-      { notificationContainerId = top `unlessUse` (view c')
-      , notificationSegment = Just $ view c'
-      , notificationCommentId = Just $ view c'
+      { notificationContainerId = top `unlessUse` ((containerId . containerRow . slotContainer . commentSlot) c')
+      , notificationSegment = Just $ (slotSegment . commentSlot) c'
+      , notificationCommentId = Just $ commentId c'
       }
-  createVolumeNotification (view c') $ \n -> (n NoticeCommentVolume)
-    { notificationContainerId = top `unlessUse` (view c')
-    , notificationSegment = Just $ view c'
-    , notificationCommentId = Just $ view c'
+  createVolumeNotification ((containerVolume . slotContainer . commentSlot) c') $ \n -> (n NoticeCommentVolume)
+    { notificationContainerId = top `unlessUse` ((containerId . containerRow . slotContainer . commentSlot) c')
+    , notificationSegment = Just $ (slotSegment . commentSlot) c'
+    , notificationCommentId = Just $ commentId c'
     }
   return $ okResponse [] $ JSON.recordEncoding $ commentJSON c'
   -- HTML -> peeks $ otherRouteResponse [] (viewSlot False) (api, (Just (view c'), slotId (commentSlot c')))

--- a/src/Controller/Container.hs
+++ b/src/Controller/Container.hs
@@ -44,7 +44,7 @@ import View.Form (FormHtml)
 getContainer :: Permission -> Maybe (Id Volume) -> Id Slot -> Bool -> Handler Container
 getContainer p mv (Id (SlotId i s)) top
   | segmentFull s = do
-    c <- checkPermission p =<< maybeAction . maybe id (\v -> mfilter $ (v ==) . view) mv =<< lookupContainer i
+    c <- checkPermission p =<< maybeAction . maybe id (\v -> mfilter $ (v ==) . volumeId . volumeRow . containerVolume) mv =<< lookupContainer i
     unless top $ do
       t <- lookupVolumeTopContainer (containerVolume c)
       when (containerId (containerRow c) == containerId (containerRow t)) $ result =<< peeks notFoundResponse
@@ -80,7 +80,7 @@ viewContainerEdit = action GET (pathHTML >/> pathMaybe pathId </> pathSlotId </<
   when (isJust vi) $ angular
   c <- getContainer PermissionEDIT vi ci False
   unless (isJust vi) $
-    result =<< peeks (redirectRouteResponse movedPermanently301 [] viewContainerEdit (Just (view c), containerSlotId (view c)))
+    result =<< peeks (redirectRouteResponse movedPermanently301 [] viewContainerEdit (Just ((volumeId . volumeRow . containerVolume) c), containerSlotId (view c)))
   return $ okResponse [] $ ("" :: String) -- should never get here
   -- peeks $ blankForm . htmlContainerEdit (Right c)
 

--- a/src/Controller/Slot.hs
+++ b/src/Controller/Slot.hs
@@ -43,7 +43,7 @@ import {-# SOURCE #-} Controller.AssetSegment
 
 getSlot :: Permission -> Maybe (Id Volume) -> Id Slot -> Handler Slot
 getSlot p mv i =
-  checkPermission p =<< maybeAction . maybe id (\v -> mfilter $ (v ==) . view) mv =<< lookupSlot i
+  checkPermission p =<< maybeAction . maybe id (\v -> mfilter $ (v ==) . volumeId . volumeRow . containerVolume . slotContainer) mv =<< lookupSlot i
 
 slotJSONField :: Bool -> Slot -> BS.ByteString -> Maybe BS.ByteString -> Handler (Maybe JSON.Encoding)
 slotJSONField getOrig o "assets" _ =
@@ -82,7 +82,8 @@ viewSlot viewOrig = action GET (pathAPI </> pathMaybe pathId </> pathSlotId) $ \
     JSON -> okResponse [] <$> (slotJSONQuery viewOrig c =<< peeks Wai.queryString)
     HTML
       | isJust vi -> return $ okResponse [] $ BSC.pack $ show $ containerId $ containerRow $ slotContainer c
-      | otherwise -> peeks $ redirectRouteResponse movedPermanently301 [] (viewSlot viewOrig) (api, (Just (view c), slotId c))
+      | otherwise ->
+          peeks $ redirectRouteResponse movedPermanently301 [] (viewSlot viewOrig) (api, (Just ((volumeId . volumeRow . containerVolume . slotContainer) c), slotId c))
 
 thumbSlot :: ActionRoute (Maybe (Id Volume), Id Slot)
 thumbSlot = action GET (pathMaybe pathId </> pathSlotId </< "thumb") $ \(vi, i) -> withAuth $ do

--- a/src/Controller/Tag.hs
+++ b/src/Controller/Tag.hs
@@ -54,8 +54,8 @@ postTag = action POST (pathAPI </>> pathSlotId </> pathTagId) $ \(api, si, TagId
   top <- containerIsVolumeTop (slotContainer s)
   createVolumeNotification (view tu) $ \n -> (n NoticeTagVolume)
     { notificationContainerId = top `unlessUse` (view tu)
-    , notificationSegment = Just $ view tu
-    , notificationTag = Just $ view tu
+    , notificationSegment = Just $ (view . tagSlot) tu
+    , notificationTag = Just $ useTag tu
     }
   tagResponse api tu
 

--- a/src/Model/Asset/Types.hs
+++ b/src/Model/Asset/Types.hs
@@ -14,7 +14,6 @@ import qualified Data.Text as T
 import Has (Has(..))
 import Model.Offset
 import Model.Kind
--- import Model.Permission.Types
 import Model.Release.Types
 import Model.Id.Types
 import Model.Volume.Types
@@ -31,28 +30,21 @@ data AssetRow = AssetRow
   , assetSHA1 :: Maybe BS.ByteString
   , assetSize :: Maybe Int64
   }
-  -- deriving (Show)
+
 data Asset = Asset
   { assetRow :: !AssetRow
   , assetVolume :: Volume
   }
-  -- deriving (Show)
 
 instance Kinded Asset where
   kindOf _ = "asset"
 
--- makeHasRec ''AssetRow ['assetId, 'assetFormat, 'assetRelease]
--- makeHasRec ''Asset ['assetRow, 'assetVolume]
 instance Has (Id Asset) AssetRow where
   view = assetId
 instance Has Format AssetRow where
   view = assetFormat
 instance Has (Id Format) AssetRow where
   view = (formatId . assetFormat)
--- instance Has (Maybe Release) AssetRow where
---   view = assetRelease
--- instance Has Release AssetRow where
---   view = (view . assetRelease)
 
 instance Has AssetRow Asset where
   view = assetRow
@@ -62,18 +54,10 @@ instance Has Format Asset where
   view = (view . assetRow)
 instance Has (Id Format) Asset where
   view = (view . assetRow)
--- instance Has (Maybe Release) Asset where
---   view = (view . assetRow)
--- instance Has Release Asset where
---   view = (view . assetRow)
 instance Has Volume Asset where
    view = assetVolume
--- instance Has Permission Asset where
---   view = (view . assetVolume)
 instance Has (Id Volume) Asset where
-  view = (view . assetVolume)
--- instance Has VolumeRow Asset where
---   view = (view . assetVolume)
+  view = (volumeId . volumeRow . assetVolume)
 
 getAssetReleaseMaybe :: Asset -> Maybe Release
 getAssetReleaseMaybe = assetRelease . assetRow

--- a/src/Model/AssetRevision.hs
+++ b/src/Model/AssetRevision.hs
@@ -192,7 +192,7 @@ lookupAssetReplace a = do
           vname_abkPr, vc_abkPs, vsize_abkPt, vid_abkPu, vname_abkPv,
           vbody_abkPw, valias_abkPx, vdoi_abkPy, vc_abkPz, vowners_abkPA,
           vpermission_abkPB, vfull_abkPC)
-         -> makeAssetRevision
+         -> AssetRevision
               (Asset
                  (Model.Asset.SQL.makeAssetRow
                     vid_abkPn
@@ -324,7 +324,7 @@ lookupAssetTranscode a = do
           vname_abkSg, vc_abkSh, vsize_abkSi, vid_abkSj, vname_abkSk,
           vbody_abkSl, valias_abkSm, vdoi_abkSn, vc_abkSo, vowners_abkSp,
           vpermission_abkSq, vfull_abkSr)
-         -> makeAssetRevision
+         -> AssetRevision
               (Asset
                  (Model.Asset.SQL.makeAssetRow
                     vid_abkSc

--- a/src/Model/AssetRevision/Types.hs
+++ b/src/Model/AssetRevision/Types.hs
@@ -1,6 +1,5 @@
 module Model.AssetRevision.Types
   ( AssetRevision(..)
-  , makeAssetRevision
   ) where
 
 import Model.Asset.Types
@@ -10,5 +9,5 @@ data AssetRevision = AssetRevision
   , revisionOrig :: !Asset
   }
 
-makeAssetRevision :: Asset -> Asset -> AssetRevision
-makeAssetRevision o a = AssetRevision a o
+-- makeAssetRevision :: Asset -> Asset -> AssetRevision
+-- makeAssetRevision o a = AssetRevision a o

--- a/src/Model/AssetSegment/Types.hs
+++ b/src/Model/AssetSegment/Types.hs
@@ -37,7 +37,6 @@ data AssetSegment = AssetSegment
   , assetSegment :: !Segment
   , assetExcerpt :: Maybe Excerpt
   }
-  -- deriving (Show)
 
 assetAssumedSegment :: AssetSlot -> Segment
 assetAssumedSegment a
@@ -73,7 +72,7 @@ getAssetSegmentVolume = getAssetSlotVolume . segmentAsset
 instance Has Volume AssetSegment where
   view = view . segmentAsset
 instance Has (Id Volume) AssetSegment where
-  view = view . segmentAsset
+  view = volumeId . volumeRow . assetVolume . slotAsset . segmentAsset
 getAssetSegmentVolumePermission2 :: AssetSegment -> VolumeRolePolicy
 getAssetSegmentVolumePermission2 = getAssetSlotVolumePermission2 . segmentAsset
 
@@ -147,8 +146,8 @@ instance Has (Id Asset) Excerpt where
   view = view . excerptAsset
 instance Has Volume Excerpt where
   view = view . excerptAsset
-instance Has (Id Volume) Excerpt where
-  view = view . excerptAsset
+{- instance Has (Id Volume) Excerpt where
+  view = view . excerptAsset -}
 instance Has Slot Excerpt where
   view = view . excerptAsset
 instance Has Container Excerpt where

--- a/src/Model/AssetSlot/Types.hs
+++ b/src/Model/AssetSlot/Types.hs
@@ -25,7 +25,6 @@ import Model.Container.Types
 import Model.Format.Types
 import Model.Asset.Types
 import Model.Slot.Types
--- import Model.Asset (blankAsset)
 
 data AssetSlotId = AssetSlotId
   { slotAssetId :: !(Id Asset)
@@ -39,7 +38,6 @@ data AssetSlot = AssetSlot
   { slotAsset :: Asset
   , assetSlot :: Maybe Slot
   }
-  -- deriving (Show)
 
 assetSlotId :: AssetSlot -> Id AssetSlot
 assetSlotId (AssetSlot a s) = Id $ AssetSlotId (assetId $ assetRow a) (slotId <$> s)

--- a/src/Model/Category/Types.hs
+++ b/src/Model/Category/Types.hs
@@ -10,7 +10,6 @@ import qualified Data.Text as T
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift (deriveLift)
 
-import Has (Has(..))
 import Model.Kind
 import Model.Id.Types
 
@@ -31,9 +30,5 @@ instance Eq Category where
 
 instance Ord Category where
   compare = comparing categoryId
-
--- makeHasRec ''Category ['categoryId]
-instance Has (Id Category) Category where
-  view = categoryId
 
 deriveLift ''Category

--- a/src/Model/Category/Types.hs
+++ b/src/Model/Category/Types.hs
@@ -5,7 +5,6 @@ module Model.Category.Types
 
 import Data.Function (on)
 import Data.Int (Int16)
-import Data.Ord (comparing)
 import qualified Data.Text as T
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift (deriveLift)
@@ -27,8 +26,5 @@ instance Kinded Category where
 instance Eq Category where
   (==) = on (==) categoryId
   (/=) = on (/=) categoryId
-
-instance Ord Category where
-  compare = comparing categoryId
 
 deriveLift ''Category

--- a/src/Model/Citation/Types.hs
+++ b/src/Model/Citation/Types.hs
@@ -32,13 +32,10 @@ instance Monoid Citation where
     , citationTitle = citationTitle a <|> citationTitle b
     }
 
-citationJSON :: JSON.ToObject o => Citation -> o
-citationJSON Citation{..} =
-     "head" JSON..= citationHead
-  <> "title" `JSON.kvObjectOrEmpty` citationTitle
-  <> "url" `JSON.kvObjectOrEmpty` citationURL
-  <> "year" `JSON.kvObjectOrEmpty` citationYear
-
 instance JSON.ToJSON Citation where
-  toJSON = JSON.object . citationJSON
-  toEncoding = JSON.pairs . citationJSON
+    toJSON Citation{..} =
+        JSON.object
+            (   "head" JSON..= citationHead
+             <> "title" `JSON.kvObjectOrEmpty` citationTitle
+             <> "url" `JSON.kvObjectOrEmpty` citationURL
+             <> "year" `JSON.kvObjectOrEmpty` citationYear)

--- a/src/Model/Comment/Types.hs
+++ b/src/Model/Comment/Types.hs
@@ -5,7 +5,6 @@ module Model.Comment.Types
   , makeComment
   ) where
 
--- import qualified Data.Time as Time
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 
@@ -15,8 +14,6 @@ import Model.Kind
 import Model.Time
 import Model.Id.Types
 import Model.Party.Types
--- import Model.Permission.Types
--- import Model.Release.Types
 import Model.Segment
 import Model.Slot.Types
 import Model.Volume.Types
@@ -35,43 +32,16 @@ data Comment = Comment
 instance Kinded Comment where
   kindOf _ = "comment"
 
--- makeHasRec ''Comment ['commentId, 'commentWho, 'commentSlot, 'commentTime]
 instance Has (Id Comment) Comment where
   view = commentId
--- instance Has Account Comment where
---   view = commentWho
--- instance Has (Id Party) Comment where
---   view = (view . commentWho)
--- instance Has PartyRow Comment where
---   view = (view . commentWho)
--- instance Has Party Comment where
---   view = (view . commentWho)
--- instance Has Slot Comment where
---   view = commentSlot
 instance Has Model.Segment.Segment Comment where
   view = (view . commentSlot)
--- instance Has Model.Container.Types.ContainerRow Comment where
---   view = (view . commentSlot)
 instance Has (Id Model.Container.Types.Container) Comment where
   view = (view . commentSlot)
--- instance Has (Maybe Model.Release.Types.Release) Comment where
---   view = (view . commentSlot)
--- instance Has Model.Release.Types.Release Comment where
---   view = (view . commentSlot)
 instance Has Model.Volume.Types.Volume Comment where
   view = (view . commentSlot)
--- instance Has Model.Permission.Types.Permission Comment where
---   view = (view . commentSlot)
-instance Has (Id Model.Volume.Types.Volume) Comment where
-  view = (view . commentSlot)
--- instance Has Model.Volume.Types.VolumeRow Comment where
---   view = (view . commentSlot)
--- instance Has Model.Container.Types.Container Comment where
---   view = (view . commentSlot)
--- instance Has Timestamp Comment where
---   view = commentTime
--- instance Has Time.Day Comment where
---   view = (Time.utctDay . commentTime)
+{- instance Has (Id Model.Volume.Types.Volume) Comment where
+  view = (view . commentSlot) -}
 
 data CommentRow = CommentRow
   { commentRowId :: Id Comment

--- a/src/Model/Comment/Types.hs
+++ b/src/Model/Comment/Types.hs
@@ -8,7 +8,6 @@ module Model.Comment.Types
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 
-import Has (Has(..))
 import Model.Container.Types
 import Model.Kind
 import Model.Time
@@ -16,7 +15,6 @@ import Model.Id.Types
 import Model.Party.Types
 import Model.Segment
 import Model.Slot.Types
-import Model.Volume.Types
 
 type instance IdType Comment = Int32
 
@@ -31,17 +29,6 @@ data Comment = Comment
 
 instance Kinded Comment where
   kindOf _ = "comment"
-
-instance Has (Id Comment) Comment where
-  view = commentId
-instance Has Model.Segment.Segment Comment where
-  view = (view . commentSlot)
-instance Has (Id Model.Container.Types.Container) Comment where
-  view = (view . commentSlot)
-instance Has Model.Volume.Types.Volume Comment where
-  view = (view . commentSlot)
-{- instance Has (Id Model.Volume.Types.Volume) Comment where
-  view = (view . commentSlot) -}
 
 data CommentRow = CommentRow
   { commentRowId :: Id Comment

--- a/src/Model/Container/Types.hs
+++ b/src/Model/Container/Types.hs
@@ -56,6 +56,6 @@ instance Has Volume Container where
   view = containerVolume
 instance Has Permission Container where
   view = (view . containerVolume)
-instance Has (Id Volume) Container where
+{- instance Has (Id Volume) Container where
   view = (view . containerVolume)
-
+-}

--- a/src/Model/Container/Types.hs
+++ b/src/Model/Container/Types.hs
@@ -24,7 +24,7 @@ data ContainerRow = ContainerRow
   , containerTop :: Bool
   , containerName :: Maybe T.Text
   , containerDate :: Maybe Date
-  } -- deriving (Eq, Show)
+  }
 
 data Container = Container
   { containerRow :: !ContainerRow
@@ -56,6 +56,4 @@ instance Has Volume Container where
   view = containerVolume
 instance Has Permission Container where
   view = (view . containerVolume)
-{- instance Has (Id Volume) Container where
-  view = (view . containerVolume)
--}
+

--- a/src/Model/Format/Types.hs
+++ b/src/Model/Format/Types.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift (deriveLift)
 
-import Model.Kind
+-- import Model.Kind
 import Model.Id.Types
 
 type instance IdType Format = Int16

--- a/src/Model/Format/Types.hs
+++ b/src/Model/Format/Types.hs
@@ -23,12 +23,11 @@ data Format = Format
   , formatName :: T.Text
   }
 
-instance Kinded Format where
-  kindOf _ = "format"
+-- instance Kinded Format where
+--  kindOf _ = "format"
 
 instance Eq Format where
   (==) = on (==) formatId
-  (/=) = on (/=) formatId
 
 deriveLift ''Format
 

--- a/src/Model/Format/Types.hs
+++ b/src/Model/Format/Types.hs
@@ -7,7 +7,6 @@ module Model.Format.Types
 import qualified Data.ByteString as BS
 import Data.Function (on)
 import Data.Int (Int16)
-import Data.Ord (comparing)
 import qualified Data.Text as T
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift (deriveLift)
@@ -23,7 +22,6 @@ data Format = Format
   , formatExtension :: [BS.ByteString] -- TODO: nonempty list
   , formatName :: T.Text
   }
-  -- deriving (Show)
 
 instance Kinded Format where
   kindOf _ = "format"
@@ -31,9 +29,6 @@ instance Kinded Format where
 instance Eq Format where
   (==) = on (==) formatId
   (/=) = on (/=) formatId
-
-instance Ord Format where
-  compare = comparing formatId
 
 deriveLift ''Format
 

--- a/src/Model/Funding/Types.hs
+++ b/src/Model/Funding/Types.hs
@@ -7,7 +7,6 @@ module Model.Funding.Types
 import Data.Int (Int64)
 import qualified Data.Text as T
 
--- import Has (Has(..))
 import Model.Kind
 import Model.Id.Types
 
@@ -16,11 +15,7 @@ type instance IdType Funder = Int64
 data Funder = Funder
   { funderId :: Id Funder
   , funderName :: T.Text
-  } -- deriving (Eq, Show)
-
--- makeHasRec ''Funder ['funderId]
--- instance Has (Id Funder) Funder where
---   view = funderId
+  }
 
 instance Kinded Funder where
   kindOf _ = "funder"
@@ -28,10 +23,4 @@ instance Kinded Funder where
 data Funding = Funding
   { fundingFunder :: Funder
   , fundingAwards :: [T.Text]
-  } -- deriving (Eq, Show)
-
--- makeHasRec ''Funding ['fundingFunder]
--- instance Has Funder Funding where
---   view = fundingFunder
--- instance Has (Id Funder) Funding where
---   view = (view . fundingFunder)
+  }

--- a/src/Model/Record/Types.hs
+++ b/src/Model/Record/Types.hs
@@ -91,7 +91,7 @@ instance Has (Id Record) RecordRow where
 instance Has Category RecordRow where
   view = recordCategory
 instance Has (Id Category) RecordRow where
-  view = (view . recordCategory)
+  view = (categoryId . recordCategory)
 
 instance Has (Id Record) Record where
   view = (view . recordRow)
@@ -103,8 +103,6 @@ instance Has Volume Record where
   view = recordVolume
 instance Has Permission Record where
   view = (view . recordVolume)
-{-instance Has (Id Volume) Record where
-  view = (view . recordVolume) -}
 instance Has (Maybe Release) Record where
   view = recordRelease
 instance Has Release Record where

--- a/src/Model/Record/Types.hs
+++ b/src/Model/Record/Types.hs
@@ -9,7 +9,6 @@ module Model.Record.Types
   , ParticipantRecord(..)
   , FieldUse(..)
   , getRecordVolumePermission
-  -- , ParticipantFieldMapping(..)
   , Measure(..)
   , Measures
   , blankRecord
@@ -34,7 +33,7 @@ type instance IdType Record = Int32
 data RecordRow = RecordRow
   { recordId :: Id Record
   , recordCategory :: Category
-  } -- deriving ({-Show, -} Eq)
+  }
 
 data Record = Record
   { recordRow :: !RecordRow
@@ -73,7 +72,6 @@ data ParticipantRecord =
         , prdState :: FieldUse ByteString
         , prdSetting :: FieldUse ByteString
         } 
-    -- deriving (Show, Eq, Ord)
 
 data Measure = Measure
   { measureRecord :: Record
@@ -88,8 +86,6 @@ instance Kinded Measure where
 
 type Measures = [Measure]
 
--- makeHasRec ''RecordRow ['recordId, 'recordCategory]
--- makeHasRec ''Record ['recordRow, 'recordVolume, 'recordRelease]
 instance Has (Id Record) RecordRow where
   view = recordId
 instance Has Category RecordRow where
@@ -97,8 +93,6 @@ instance Has Category RecordRow where
 instance Has (Id Category) RecordRow where
   view = (view . recordCategory)
 
--- instance Has RecordRow Record where
---   view = recordRow
 instance Has (Id Record) Record where
   view = (view . recordRow)
 instance Has Category Record where
@@ -109,10 +103,8 @@ instance Has Volume Record where
   view = recordVolume
 instance Has Permission Record where
   view = (view . recordVolume)
-instance Has (Id Volume) Record where
-  view = (view . recordVolume)
--- instance Has VolumeRow Record where
---   view = (view . recordVolume)
+{-instance Has (Id Volume) Record where
+  view = (view . recordVolume) -}
 instance Has (Maybe Release) Record where
   view = recordRelease
 instance Has Release Record where
@@ -123,25 +115,6 @@ getRecordVolumePermission = volumeRolePolicy . recordVolume
 
 instance Has Record Measure where
   view = measureRecord
--- instance Has (Id Record) Measure where
---   view = recordId . recordRow . measureRecord
--- instance Has Volume Measure where
---   view = view . measureRecord
--- instance Has (Id Volume) Measure where
---   view = view . measureRecord
--- instance Has Category Measure where
---   view = view . measureRecord
--- instance Has (Id Category) Measure where
----  view = view . measureRecord
--- instance Has Permission Measure where
---    view = view . measureRecord
-
--- instance Has Metric Measure where
---   view = measureMetric
--- instance Has (Id Metric) Measure where
---   view = view . measureMetric
--- instance Has MeasureType Measure where
---   view = view . measureMetric
 
 instance Has (Maybe Release) Measure where
   view m = metricRelease (measureMetric m) <|> recordRelease (measureRecord m)

--- a/src/Model/Record/Types.hs
+++ b/src/Model/Record/Types.hs
@@ -79,26 +79,19 @@ data Measure = Measure
   , measureDatum :: !MeasureDatum
   }
 
-instance Kinded Measure where
-  kindOf _ = "measure"
+-- instance Kinded Measure where
+--   kindOf _ = "measure"
 
 -- TODO: example building circular Record + Measure
 
 type Measures = [Measure]
 
-instance Has (Id Record) RecordRow where
-  view = recordId
-instance Has Category RecordRow where
-  view = recordCategory
-instance Has (Id Category) RecordRow where
-  view = (categoryId . recordCategory)
-
 instance Has (Id Record) Record where
-  view = (view . recordRow)
+  view = (recordId . recordRow)
 instance Has Category Record where
-  view = (view . recordRow)
+  view = (recordCategory . recordRow)
 instance Has (Id Category) Record where
-  view = (view . recordRow)
+  view = (categoryId . recordCategory . recordRow)
 instance Has Volume Record where
   view = recordVolume
 instance Has Permission Record where

--- a/src/Model/RecordSlot/Types.hs
+++ b/src/Model/RecordSlot/Types.hs
@@ -45,8 +45,8 @@ instance Has (Id Category) RecordSlot where
   view = view . slotRecord
 instance Has Volume RecordSlot where
   view = view . slotRecord
-instance Has (Id Volume) RecordSlot where
-  view = view . slotRecord
+{- instance Has (Id Volume) RecordSlot where
+  view = view . slotRecord -}
 getRecordSlotVolumePermission :: RecordSlot -> VolumeRolePolicy
 getRecordSlotVolumePermission = getRecordVolumePermission . slotRecord
 

--- a/src/Model/Slot/Types.hs
+++ b/src/Model/Slot/Types.hs
@@ -46,8 +46,8 @@ instance Kinded Slot where
 
 instance Has Container Slot where
   view = slotContainer
-instance Has (Id Model.Volume.Types.Volume) Slot where
-  view = (view . slotContainer)
+{- instance Has (Id Model.Volume.Types.Volume) Slot where
+  view = (view . slotContainer) -}
 instance Has Model.Permission.Types.Permission Slot where
   view = (view . slotContainer)
 instance Has Model.Volume.Types.Volume Slot where

--- a/src/Model/Tag/Types.hs
+++ b/src/Model/Tag/Types.hs
@@ -58,12 +58,6 @@ data Tag = Tag
   , tagName :: TagName
   }
 
--- makeHasRec ''Tag ['tagId, 'tagName]
--- instance Has (Id Tag) Tag where
---   view = tagId
--- instance Has TagName Tag where
---   view = tagName
-
 instance Kinded Tag where
   kindOf _ = "tag"
 
@@ -74,43 +68,16 @@ data TagUse = TagUse
   , tagSlot :: Slot
   }
 
--- makeHasRec ''TagUse ['useTag, 'tagWho, 'tagSlot]
 instance Has Tag TagUse where
   view = useTag
--- instance Has (Id Tag) TagUse where
---   view = (view . useTag)
--- instance Has TagName TagUse where
---   view = (view . useTag)
--- instance Has Account TagUse where
---   view = tagWho
--- instance Has (Id Party) TagUse where
---   view = (view . tagWho)
--- instance Has PartyRow TagUse where
---   view = (view . tagWho)
--- instance Has Party TagUse where
---   view = (view . tagWho)
--- instance Has Slot TagUse where
---   view = tagSlot
 instance Has Segment TagUse where
   view = (view . tagSlot)
--- instance Has ContainerRow TagUse where
---   view = (view . tagSlot)
 instance Has (Id Container) TagUse where
   view = (view . tagSlot)
--- instance Has (Maybe Model.Release.Types.Release) TagUse where
---   view = (view . tagSlot)
--- instance Has Model.Release.Types.Release TagUse where
---   view = (view . tagSlot)
 instance Has Model.Volume.Types.Volume TagUse where
   view = (view . tagSlot)
--- instance Has Model.Permission.Types.Permission TagUse where
---   view = (view . tagSlot)
 instance Has (Id Model.Volume.Types.Volume) TagUse where
-  view = (view . tagSlot)
--- instance Has Model.Volume.Types.VolumeRow TagUse where
---   view = (view . tagSlot)
--- instance Has Container TagUse where
---   view = (view . tagSlot)
+  view = (volumeId . volumeRow . containerVolume . slotContainer . tagSlot)
 
 data TagUseRow = TagUseRow
   { useTagRow :: Tag
@@ -124,14 +91,6 @@ data TagWeight = TagWeight
   , tagWeightWeight :: Int32
   }
 
--- makeHasRec ''TagWeight ['tagWeightTag]
--- instance Has Tag TagWeight where
---   view = tagWeightTag
--- instance Has (Id Tag) TagWeight where
---   view = (view . tagWeightTag)
--- instance Has TagName TagWeight where
---   view = (view . tagWeightTag)
-
 data TagCoverage = TagCoverage
   { tagCoverageWeight :: !TagWeight
   , tagCoverageContainer :: Container
@@ -139,31 +98,3 @@ data TagCoverage = TagCoverage
   , tagCoverageKeywords
   , tagCoverageVotes :: [Segment]
   }
-
--- makeHasRec ''TagCoverage ['tagCoverageWeight, 'tagCoverageContainer]
--- instance Has TagWeight TagCoverage where
---   view = tagCoverageWeight
--- instance Has Tag TagCoverage where
---   view = (view . tagCoverageWeight)
--- instance Has (Id Tag) TagCoverage where
---   view = (view . tagCoverageWeight)
--- instance Has TagName TagCoverage where
---   view = (view . tagCoverageWeight)
--- instance Has Container TagCoverage where
---   view = tagCoverageContainer
--- instance Has Model.Volume.Types.VolumeRow TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has (Id Model.Volume.Types.Volume) TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has Model.Permission.Types.Permission TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has Model.Volume.Types.Volume TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has Model.Release.Types.Release TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has (Maybe Model.Release.Types.Release) TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has (Id Container) TagCoverage where
---   view = (view . tagCoverageContainer)
--- instance Has ContainerRow TagCoverage where
---   view = (view . tagCoverageContainer)

--- a/src/Model/Tag/Types.hs
+++ b/src/Model/Tag/Types.hs
@@ -68,10 +68,6 @@ data TagUse = TagUse
   , tagSlot :: Slot
   }
 
-instance Has Tag TagUse where
-  view = useTag
-instance Has Segment TagUse where
-  view = (view . tagSlot)
 instance Has (Id Container) TagUse where
   view = (view . tagSlot)
 instance Has Model.Volume.Types.Volume TagUse where

--- a/src/Model/Token/Types.hs
+++ b/src/Model/Token/Types.hs
@@ -25,7 +25,6 @@ data Token = Token
   , tokenExpires :: Timestamp
   }
 
--- makeHasRec ''Token ['tokenId]
 instance Has (Id Token) Token where
   view = tokenId
 
@@ -34,9 +33,6 @@ data AccountToken = AccountToken
   , tokenAccount :: SiteAuth
   }
 
--- makeHasRec ''AccountToken ['accountToken, 'tokenAccount]
--- instance Has Token AccountToken where
---   view = accountToken
 instance Has (Id Token) AccountToken where
   view = (view . accountToken)
 instance Has SiteAuth AccountToken where
@@ -45,10 +41,6 @@ instance Has Access AccountToken where
   view = (view . tokenAccount)
 instance Has (Id Party) AccountToken where
   view = (view . tokenAccount)
--- instance Has PartyRow AccountToken where
---   view = (view . tokenAccount)
--- instance Has Party AccountToken where
---   view = (view . tokenAccount)
 instance Has Account AccountToken where
   view = (view . tokenAccount)
 
@@ -63,25 +55,10 @@ type instance IdType LoginToken = BS.ByteString
 instance Kinded LoginToken where
   kindOf _ = "token"
 
--- makeHasRec ''LoginToken ['loginAccountToken]
--- instance Has AccountToken LoginToken where
---   view = loginAccountToken
--- instance Has Token LoginToken where
---   view = (view . loginAccountToken)
 instance Has (Id Token) LoginToken where
   view = (view . loginAccountToken)
 instance Has SiteAuth LoginToken where
   view = (view . loginAccountToken)
--- instance Has Access LoginToken where
---   view = (view . loginAccountToken)
--- instance Has (Id Party) LoginToken where
---   view = (view . loginAccountToken)
--- instance Has PartyRow LoginToken where
---   view = (view . loginAccountToken)
--- instance Has Party LoginToken where
---   view = (view . loginAccountToken)
--- instance Has Account LoginToken where
---   view = (view . loginAccountToken)
 
 data Session = Session
   { sessionAccountToken :: !AccountToken
@@ -89,23 +66,12 @@ data Session = Session
   , sessionSuperuser :: Bool
   }
 
--- makeHasRec ''Session ['sessionAccountToken]
--- instance Has AccountToken Session where
---   view = sessionAccountToken
--- instance Has Token Session where
---   view = (view . sessionAccountToken)
 instance Has (Id Token) Session where
   view = (view . sessionAccountToken)
--- instance Has SiteAuth Session where
---   view = (view . sessionAccountToken)
 instance Has Access Session where
   view = (view . sessionAccountToken)
 instance Has (Id Party) Session where
   view = (view . sessionAccountToken)
--- instance Has PartyRow Session where
---   view = (view . sessionAccountToken)
--- instance Has Party Session where
---   view = (view . sessionAccountToken)
 instance Has Account Session where
   view = (view . sessionAccountToken)
 
@@ -115,25 +81,8 @@ data Upload = Upload
   , uploadSize :: Int64
   }
 
--- makeHasRec ''Upload ['uploadAccountToken]
--- instance Has AccountToken Upload where
---   view = uploadAccountToken
--- instance Has Token Upload where
---   view = (view . uploadAccountToken)
 instance Has (Id Token) Upload where
   view = (view . uploadAccountToken)
--- instance Has SiteAuth Upload where
---   view = (view . uploadAccountToken)
--- instance Has Access Upload where
---   view = (view . uploadAccountToken)
--- instance Has (Id Party) Upload where
---   view = (view . uploadAccountToken)
--- instance Has PartyRow Upload where
---   view = (view . uploadAccountToken)
--- instance Has Party Upload where
---   view = (view . uploadAccountToken)
--- instance Has Account Upload where
---   view = (view . uploadAccountToken)
 
 makeUpload :: Token -> BS.ByteString -> Int64 -> SiteAuth -> Upload
 makeUpload t n z u = Upload (AccountToken t u) n z

--- a/src/Model/Volume/Types.hs
+++ b/src/Model/Volume/Types.hs
@@ -44,8 +44,8 @@ data Volume = Volume
 instance Kinded Volume where
   kindOf _ = "volume"
 
-instance Has (Id Volume) Volume where
-  view = (volumeId . volumeRow)
+{- instance Has (Id Volume) Volume where
+  view = (volumeId . volumeRow) -}
 instance Has Permission Volume where
   view = extractPermissionIgnorePolicy . volumeRolePolicy
 deriveLiftMany [''VolumeRow, ''Volume]

--- a/src/Model/Volume/Types.hs
+++ b/src/Model/Volume/Types.hs
@@ -31,7 +31,6 @@ data VolumeRow = VolumeRow
   , volumeAlias :: Maybe T.Text
   , volumeDOI :: Maybe BS.ByteString
   }
-  -- deriving (Show, Eq)
 
 type VolumeOwner = (Id Party, T.Text)
 
@@ -41,15 +40,12 @@ data Volume = Volume
   , volumeOwners :: [VolumeOwner]
   , volumeRolePolicy :: VolumeRolePolicy
   }
-  -- deriving (Show, Eq)
 
 instance Kinded Volume where
   kindOf _ = "volume"
 
-instance Has (Id Volume) VolumeRow where
-  view = volumeId
 instance Has (Id Volume) Volume where
-  view = (view . volumeRow)
+  view = (volumeId . volumeRow)
 instance Has Permission Volume where
   view = extractPermissionIgnorePolicy . volumeRolePolicy
 deriveLiftMany [''VolumeRow, ''Volume]

--- a/src/Model/VolumeAccess/Types.hs
+++ b/src/Model/VolumeAccess/Types.hs
@@ -6,7 +6,6 @@ module Model.VolumeAccess.Types
 
 import Data.Int (Int16)
 
--- import Has (Has(..))
 import Model.Id.Types
 import Model.Permission.Types
 import Model.Volume.Types
@@ -30,14 +29,3 @@ getShareFullDefault targetParty individualAccessLevel =
     nobodyId = (getPartyId . accountParty . siteAccount) nobodySiteAuth
     nobodyPublicLegacyDefault = Just True
     generalDefault = Nothing
-
-{-
-instance Has Volume VolumeAccess where
-  view = volumeAccessVolume
-instance Has (Id Volume) VolumeAccess where
-  view = (Has.view . volumeAccessVolume)
-instance Has Party VolumeAccess where
-  view = volumeAccessParty
-instance Has (Id Party) VolumeAccess where
-  view = (view . volumeAccessParty)
--}

--- a/src/Service/Periodic.hs
+++ b/src/Service/Periodic.hs
@@ -41,7 +41,7 @@ run p = runContextM $ withReaderT BackgroundContext $ do
   focusIO $ logMsg t ("periodic running: " ++ show p)
   cleanTokens
   updateVolumeIndex
-  updateIndex
+  withReaderT (mkSolrIndexingContext . backgroundContext) updateIndex
   ss <- lookupSiteStats
   focusIO $ (`writeIORef` ss) . serviceStats
   when (p >= PeriodWeekly) $

--- a/test/ModelTest.hs
+++ b/test/ModelTest.hs
@@ -426,7 +426,7 @@ test_15 = Test.stepsWithTransaction "test_15" $ \step cn2 -> do
 ------- search -------------
 test_16 :: TestTree
 test_16 = ignoreTest $ -- TODO: enable this inside of nix build with solr binaries and core installed in precheck
-    Test.stepsWithResourceAndTransaction "test_16" $ \step ist cn2 -> do
+    Test.stepsWithTransaction "test_16" $ \step cn2 -> do
         step "Given an authorized investigator"
         (aiAcct, aiCtxt) <- addAuthorizedInvestigatorWithInstitution' cn2
         step "When the AI creates a partially shared volume and the search index is updated"
@@ -442,7 +442,7 @@ test_16 = ignoreTest $ -- TODO: enable this inside of nix build with solr binari
         show resVal @?= -- TODO: use aeson parser and only check selected fields
             "Object (fromList [(\"response\",Object (fromList [(\"numFound\",Number 1.0),(\"start\",Number 0.0),(\"docs\",Array [Object (fromList [(\"body\",String \"Databrary is an open data library for developmental science. Share video, audio, and related metadata. Discover more, faster.\\nMost developmental scientists rely on video recordings to capture the complexity and richness of behavior. However, researchers rarely share video data, and this has impeded scientific progress. By creating the cyber-infrastructure and community to enable open video sharing, the Databrary project aims to facilitate deeper, richer, and broader understanding of behavior.\\nThe Databrary project is dedicated to transforming the culture of developmental science by building a community of researchers committed to open video data sharing, training a new generation of developmental scientists and empowering them with an unprecedented set of tools for discovery, and raising the profile of behavioral science by bolstering interest in and support for scientific research among the general public.\"),(\"name\",String \"Databrary\"),(\"owner_names\",Array [String \"Admin, Admin\",String \"Steiger, Lisa\",String \"Tesla, Testarosa\"]),(\"id\",Number 1.0),(\"owner_ids\",Array [Number 1.0,Number 3.0,Number 7.0])])])])),(\"spellcheck\",Object (fromList [(\"suggestions\",Array [])]))])"
         step "and the public will find the newly added volume by title"
-        bctx <- mkBackgroundContext (ForSolr solr) ist cn2
+        bctx <- mkSolrIndexingContextSimple cn2 solr
         runReaderT updateIndex bctx
         _ <- runReaderT (search (mkVolumeSearchQuery ((volumeName . volumeRow) vol))) (aiCtxt { ctxSolr = Just solr, ctxHttpClient = Just hc})
         -- TODO: assert one result, and result name matches volume title searched for

--- a/test/TestHarness.hs
+++ b/test/TestHarness.hs
@@ -1,6 +1,7 @@
 module TestHarness
     (
-      ContextFor(..)
+      mkSolrIndexingContextSimple
+    , ContextFor(..)
     , mkBackgroundContext
     , TestContext ( .. )
     , mkRequest
@@ -100,15 +101,29 @@ expect a matcher = case res of
   (MatchFailure msg) -> assertFailure msg
   where res = runMatch matcher a
 
-data ContextFor = ForEzid | ForSolr Solr
+-- | Build the specialized context needed for solr indexing to run, with defaults for simple values
+mkSolrIndexingContextSimple :: PGConnection -> Solr -> IO SolrIndexingContext
+mkSolrIndexingContextSimple cn solr = do
+    conf <- C.load "databrary.conf"
+    logs <- initLogs (conf C.! "log")
+    httpc <- initHTTPClient
+    pure
+      SolrIndexingContext {
+               slcTimestamp = UTCTime (fromGregorian 2018 4 5) (secondsToDiffTime 0)
+             , slcLogs = logs
+             , slcHTTPClient = httpc
+             , slcSolr = solr
+             , slcDB = cn
+             }
+
+data ContextFor = ForEzid
 
 -- | Build a specialized context needed to background jobs that use a small subset of services
 mkBackgroundContext :: ContextFor -> InternalState -> PGConnection -> IO BackgroundContext
 mkBackgroundContext ctxtFor ist cn =
-    -- TODO: make a smaller context for solr indexing to use, so stubs aren't needed
+    -- TODO: make a smaller context for ezid to use, so stubs aren't needed
     -- stubs
     let stubSolr = Solr { solrRequest = error "no solr req", solrProcess = Nothing }
-        stubEzid = Nothing
         stubStorage = Storage undefined Nothing undefined undefined Nothing Nothing Nothing
         stubStatic = Static "" "" Nothing (\_ -> error "no val")
         stats = error "siteStats"
@@ -118,7 +133,6 @@ mkBackgroundContext ctxtFor ist cn =
     logs <- initLogs (conf C.! "log")
     httpc <- initHTTPClient
     (solr, ezid) <- case ctxtFor of
-          ForSolr solrInst -> pure (solrInst, stubEzid)
           ForEzid -> do
               ezidInst <- initEZID (conf C.! "ezid")
               pure (stubSolr, ezidInst)

--- a/test/TestHarness.hs
+++ b/test/TestHarness.hs
@@ -109,8 +109,7 @@ mkSolrIndexingContextSimple cn solr = do
     httpc <- initHTTPClient
     pure
       SolrIndexingContext {
-               slcTimestamp = UTCTime (fromGregorian 2018 4 5) (secondsToDiffTime 0)
-             , slcLogs = logs
+               slcLogs = logs
              , slcHTTPClient = httpc
              , slcSolr = solr
              , slcDB = cn


### PR DESCRIPTION
You can ignore all the minor dead code removal and removing of Has instances.

The solr context refactor is worth reviewing. I think this is universally better than what was before, so I don't expect any blocking objections. We might be able to indicate how we want to improve this further in later refactorings though. (Can probably factor out context into context needed for model layer and general context needed)

- [x] Run tests once locally with solr test enabled.