### PR TITLE
Remove dead code

### DIFF
--- a/src/HTTP/Client.hs
+++ b/src/HTTP/Client.hs
@@ -5,7 +5,7 @@ module HTTP.Client
   , checkContentOk
   , CookiesT
   , runCookiesT
-  , withCookies
+  -- , withCookies
   , withResponseCookies
   , requestAcceptContent
   , httpParse
@@ -42,11 +42,11 @@ type CookiesT m a = StateT HC.CookieJar m a
 
 runCookiesT :: Monad m => CookiesT m a -> m a
 runCookiesT f = evalStateT f mempty
-
+{-
 withCookies :: (MonadIO m, MonadHas HTTPClient c m) => (HC.Request -> HC.Manager -> IO (HC.Response a)) -> HC.Request -> CookiesT m (HC.Response a)
 withCookies f r = StateT $ \c -> focusIO $ \m ->
   (id &&& HC.responseCookieJar) <$> f r{ HC.cookieJar = HC.cookieJar r <> Just c } m
-
+-}
 withResponseCookies :: (MonadIO m, MonadHas HTTPClient c m) => HC.Request -> (HC.Response HC.BodyReader -> IO a) -> CookiesT m a
 withResponseCookies q f = StateT $ \c -> focusIO $ \m ->
   HC.withResponse q{ HC.cookieJar = HC.cookieJar q <> Just c } m $ \r -> (, HC.responseCookieJar r) <$> f r

--- a/src/HTTP/Form/Deform.hs
+++ b/src/HTTP/Form/Deform.hs
@@ -25,8 +25,8 @@ import Control.Monad (MonadPlus(..), liftM, mapAndUnzipM, guard)
 import Control.Monad.Reader (MonadReader(..), asks)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
-import Control.Monad.Trans.Control (MonadTransControl(..))
-import Control.Monad.Writer.Class (MonadWriter(..))
+-- import Control.Monad.Trans.Control (MonadTransControl(..))
+-- import Control.Monad.Writer.Class (MonadWriter(..))
 import qualified Data.Aeson as JSON
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
@@ -58,13 +58,13 @@ newtype DeformT f m a = DeformT { runDeformT :: Form f -> m (FormErrors, Maybe a
 instance MonadTrans (DeformT f) where
   lift m = DeformT $ \_ ->
     liftM ((,) mempty . Just) m
-
+{-
 instance MonadTransControl (DeformT f) where
   type StT (DeformT f) a = (FormErrors, Maybe a)
   liftWith f = DeformT $ \d ->
     liftM ((,) mempty . Just) $ f $ \t -> runDeformT t d
   restoreT m = DeformT $ \_ -> m
-
+-}
 instance MonadIO m => MonadIO (DeformT f m) where
   liftIO = lift . liftIO
 
@@ -104,7 +104,7 @@ instance Monad m => MonadReader (Form f) (DeformT f m) where
   reader f = DeformT $ \d -> return (mempty, Just (f d))
   local f (DeformT a) = DeformT $ a . f
 
-instance Monad m => MonadWriter FormErrors (DeformT f m) where
+{-instance Monad m => MonadWriter FormErrors (DeformT f m) where
   writer (a, e) = DeformT $ \_ -> return (e, Just a)
   listen (DeformT a) = DeformT $ \d -> do
     (e, r) <- a d
@@ -113,7 +113,7 @@ instance Monad m => MonadWriter FormErrors (DeformT f m) where
     (e, mrf) <- a q
     case mrf of
       Just (r, f) -> return (f e, Just r)
-      Nothing -> return (e, Nothing)
+      Nothing -> return (e, Nothing) -}
 
 runDeform :: Monad m => DeformT f m a -> FormData f -> m (Either FormErrors a)
 runDeform (DeformT fa) = fmap fr . fa . initForm where

--- a/src/HTTP/Form/View.hs
+++ b/src/HTTP/Form/View.hs
@@ -4,9 +4,9 @@ module HTTP.Form.View
   , runFormView
   , blankFormView
   , (.:>)
-  , withSubFormsViews
+--  , withSubFormsViews
   , formViewErrors
-  , allFormViewErrors
+--  , allFormViewErrors
   ) where
 
 import Control.Arrow (first, second)
@@ -69,7 +69,7 @@ blankFormView f = runFormView f mempty mempty
 withSubFormView :: Monad m => FormKey -> FormViewT f m a -> FormViewT f m a
 withSubFormView k (FormViewT a) = FormViewT $ \d e ->
   second (setSubFormErrors e k) <$> a (subForm k d) (subFormErrors k e)
-
+{-
 withSubFormsViews :: Monad m => [a] -> (Maybe a -> FormViewT f m ()) -> FormViewT f m ()
 withSubFormsViews l f = msfv 0 l =<< reader subForms where
   msfv _ [] [] = return ()
@@ -78,13 +78,14 @@ withSubFormsViews l f = msfv 0 l =<< reader subForms where
     (_, sr) = uncons sl
   uncons (x:r) = (Just x, r)
   uncons r = (Nothing, r)
-
+-}
 infixr 2 .:>
 (.:>) :: Monad m => T.Text -> FormViewT f m a -> FormViewT f m a
 (.:>) = withSubFormView . FormField
 
 formViewErrors :: Monad m => FormViewT f m [FormErrorMessage]
 formViewErrors = state $ \e -> (formErrors e, e{ formErrors = [] })
-
+{-
 allFormViewErrors :: Monad m => FormViewT f m [(FormPath, FormErrorMessage)]
 allFormViewErrors = state $ \e -> (allFormErrors e, mempty)
+-}

--- a/src/HTTP/Parse.hs
+++ b/src/HTTP/Parse.hs
@@ -32,7 +32,7 @@ requestTooLarge :: Response
 requestTooLarge = emptyResponse requestEntityTooLarge413 []
 
 type ChunkParser a = IO BS.ByteString -> IO a
-
+{-
 _mapChunks :: (a -> b) -> ChunkParser a -> ChunkParser b
 _mapChunks f parse next = f <$> parse next
 
@@ -43,7 +43,7 @@ _nullChunks next = go 0 where
     if BS.null b
       then return n
       else go (n + fromIntegral (BS.length b))
-
+-}
 limitChunks :: Word64 -> ChunkParser a -> ChunkParser a
 limitChunks lim parse next = do
   len <- liftIO $ newIORef 0
@@ -83,17 +83,17 @@ textChunks err next = run (TE.streamDecodeUtf8With err) where
 textChunks' :: ChunkParser TL.Text
 textChunks' = textChunks (\e _ -> unsafeResult $ response unsupportedMediaType415 [] e)
 
-
+{-
 _mapBackEnd :: (a -> b) -> BackEnd a -> BackEnd b
 _mapBackEnd f back param info next = f <$> back param info next
-
+-}
 rejectBackEnd :: BackEnd a
 rejectBackEnd _ _ _ = result requestTooLarge
 
-
+{-
 _parseRequestChunks :: ChunkParser a -> Handler a
 _parseRequestChunks p = liftIO . p =<< peeks requestBody
-
+-}
 limitRequestChunks :: Word64 -> ChunkParser a -> Handler a
 limitRequestChunks lim p = do
   rq <- peek


### PR DESCRIPTION
These are internal libraries scheduled for being replaced. Reduce any functions they expose as soon as we know that they are not in use. There was indication that these weren't being used by the lack of coverage in functional tests.