### PR TITLE
Remove rematch, bring in hspec-expectations

### DIFF
--- a/databrary.cabal
+++ b/databrary.cabal
@@ -478,6 +478,7 @@ test-suite discovered
     , cookie
     , cryptonite
     , hedgehog
+    , hspec-expectations >= 0.8.2
     , http-client
     , http-types
     , mtl
@@ -485,7 +486,6 @@ test-suite discovered
     , postgresql-typed
     , process
     , range-set-list
-    , rematch >= 0.2.0.0
     , resourcet
     , tasty
     , tasty-discover

--- a/databrary.nix
+++ b/databrary.nix
@@ -2,12 +2,12 @@
 , bcrypt, binary, blaze-html, blaze-markup, bytestring
 , case-insensitive, casing, cassava, conduit-combinators, containers, cookie, cracklib
 , cryptonite, data-default-class, directory, either, fast-logger, ffmpeg
-, filepath, hashable, hedgehog, hjsonschema, http-client, http-client-tls
+, filepath, hashable, hedgehog, hjsonschema, hspec-expectations, http-client, http-client-tls
 , http-types, invertible
 , lifted-base, memory, mime-mail, mime-types, monad-control, mtl
 , network, network-uri, openssl, parsec, path, path-io, posix-paths
 , postgresql-simple, postgresql-typed, process, range-set-list
-, regex-posix, rematch, resource-pool, resourcet, scientific, servant, servant-blaze, servant-server, smtp-mail
+, regex-posix, resource-pool, resourcet, scientific, servant, servant-blaze, servant-server, smtp-mail
 , stdenv, streaming-commons, stringsearch, tasty, tasty-expected-failure
 , tasty-discover, tasty-hedgehog, tasty-quickcheck, tasty-hunit, QuickCheck, template-haskell, text, th-lift, th-lift-instances
 , time, transformers, transformers-base, unix, unordered-containers
@@ -66,7 +66,7 @@ in
     filepath hashable hjsonschema http-client http-client-tls http-types
     invertible lifted-base memory mime-mail mime-types monad-control mtl network
     network-uri parsec path path-io posix-paths postgresql-simple
-    postgresql-typed process range-set-list regex-posix rematch resource-pool
+    postgresql-typed process range-set-list regex-posix resource-pool
     resourcet scientific servant servant-blaze servant-server smtp-mail
     streaming-commons stringsearch template-haskell text th-lift
     th-lift-instances time transformers transformers-base unix
@@ -83,6 +83,7 @@ in
     base
     cookie
     hedgehog
+    hspec-expectations
     http-types
     mtl
     range-set-list

--- a/test/StringUtilTest.hs
+++ b/test/StringUtilTest.hs
@@ -1,6 +1,7 @@
 module StringUtilTest
 where
 
+import Test.Hspec.Expectations
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -18,5 +19,5 @@ test_all =
     testCase "fromCamel-1"
       (fromCamel "Abc" @?= "abc")
   , testCase "fromCamel-2"
-      (fromCamel "AbcEfg" @?= "abc_efg")
+      (fromCamel "AbcEfg" `shouldBe` "abc_efg")
   ]

--- a/test/TestHarness.hs
+++ b/test/TestHarness.hs
@@ -25,7 +25,6 @@ module TestHarness
     , lookupSiteAuthNoIdent
     , switchIdentity
     -- , addAuthorization
-    , expect
     -- * re-export for convenience
     , runReaderT
     , Wai.defaultRequest
@@ -36,8 +35,6 @@ module TestHarness
 
 import Control.Applicative
 import Control.Exception (bracket)
-import Control.Rematch
-import Control.Rematch.Run
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Resource (InternalState, runResourceT, withInternalState)
 import Data.IORef (newIORef)
@@ -92,14 +89,6 @@ import Web.Types (Web(..))
 --   solr started using /solr-6.6.0 binaries w/core and config in /solr; databrary_logs created
 --   ffmpeg exe on path
 --   active internet connection for live http calls like geoname lookup to function
-
--- | Sloppily taken from hunit-rematch because author is too lazy
--- to update dependency bounds on hackage. Use fetch from his github later.
-expect :: a -> Matcher a -> Assertion
-expect a matcher = case res of
-  MatchSuccess -> return ()
-  (MatchFailure msg) -> assertFailure msg
-  where res = runMatch matcher a
 
 -- | Build the specialized context needed for solr indexing to run, with defaults for simple values
 mkSolrIndexingContextSimple :: PGConnection -> Solr -> IO SolrIndexingContext


### PR DESCRIPTION
- haven't been many reasons to use rematch
- hspec-expectations might be useful, try it out