### PR TITLE
Introduce requestVolume and Permissioned type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,9 @@ db: ; $(nix-shell) --run ./init-db-pql.sh
 .PHONY: db
 
 ## Start the dev repl
+# FIXME: ghci-databrary.sh clobbers cabal's config data.
 repl: ; $(nix-shell) --run ./ghci-databrary.sh
 .PHONY: repl
-
-## Start tests in the repl
-repl-test: ; $(nix-shell) --run 'cabal repl test:discovered'
-.PHONY: repl-test
 
 ## Run configure for repltastic tasks
 repl-config: ; $(nix-shell) --run 'cabal configure --datadir=. --datasubdir=. --disable-optimization --enable-tests'

--- a/s/update-developer-docs
+++ b/s/update-developer-docs
@@ -1,8 +1,11 @@
 #!/usr/bin/env nix-shell
-#! nix-shell ../shell.nix -i bash
-# FIXME: Add rsync and pup to the env. Use
-# https://discourse.nixos.org/t/best-way-to-augment-a-nix-shell-for-dev-utilities/157/6
-# once we finally update nixpkgs again.
+#! nix-shell --option binary-caches "https://cache.nixos.org http://devdatabrary2.home.nyu.edu:5000" ../shell.nix -i bash
+
+# FIXME:
+# 1. Add rsync and pup to the env. Use
+#    https://discourse.nixos.org/t/best-way-to-augment-a-nix-shell-for-dev-utilities/157/6
+#    once we finally update nixpkgs again.
+# 2. Figure out a better way to duplicate the use of the binary-caches option.
 set -Eeuo pipefail
 
 #
@@ -104,3 +107,5 @@ clean
 build
 report
 summary
+
+# vim: set ft=sh :

--- a/src/Controller/Activity.hs
+++ b/src/Controller/Activity.hs
@@ -23,7 +23,7 @@ import Model.Id
 import Model.Permission
 import Model.Party
 import Model.Authorize
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.VolumeAccess
 import Model.Slot
 import Model.Activity

--- a/src/Controller/Asset.hs
+++ b/src/Controller/Asset.hs
@@ -40,7 +40,7 @@ import Model.Segment
 import Model.Permission hiding (checkPermission)
 import Model.Release
 import Model.Id
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Container
 import Model.Token
 import Model.Format

--- a/src/Controller/CSV.hs
+++ b/src/Controller/CSV.hs
@@ -19,7 +19,7 @@ import Network.HTTP.Types (hContentType)
 
 import Model.Id
 import Model.Permission
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Container
 import Model.Record
 import Model.Category

--- a/src/Controller/Container.hs
+++ b/src/Controller/Container.hs
@@ -39,7 +39,6 @@ import Controller.Angular
 import Controller.Volume
 import Controller.Notification
 import {-# SOURCE #-} Controller.Slot
--- import View.Container
 import View.Form (FormHtml)
 
 getContainer :: Permission -> Maybe (Id Volume) -> Id Slot -> Bool -> Handler Container

--- a/src/Controller/Container.hs
+++ b/src/Controller/Container.hs
@@ -22,7 +22,7 @@ import Has
 import qualified JSON
 import Model.Id
 import Model.Permission hiding (checkPermission)
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Container
 import Model.Segment
 import Model.Slot

--- a/src/Controller/Funding.hs
+++ b/src/Controller/Funding.hs
@@ -12,7 +12,7 @@ import Has (focusIO)
 import qualified JSON
 import Model.Id
 import Model.Permission
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Funding
 import Model.Funding.FundRef
 import HTTP.Form.Deform

--- a/src/Controller/Ingest.hs
+++ b/src/Controller/Ingest.hs
@@ -43,7 +43,7 @@ import Model.Measure
 import Model.Metric
 import Model.Party
 import Model.Record
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.VolumeMetric
 import Model.Container
 import Ingest.Action

--- a/src/Controller/Metric.hs
+++ b/src/Controller/Metric.hs
@@ -9,7 +9,7 @@ import Control.Invertible.Monoidal ((>|<))
 import qualified Data.Aeson as Aeson
 import Model.Id
 import Model.Permission
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Category
 import Model.Metric
 import Model.VolumeMetric

--- a/src/Controller/Permission.hs
+++ b/src/Controller/Permission.hs
@@ -19,7 +19,6 @@ import Model.Identity
 import HTTP.Request
 import Action
 
-
 -- TODO: use Model.checkPermission everywhere instead
 {-# DEPRECATED checkPermissionOld "Use checkPermission instead" #-}
 checkPermissionOld :: Has Permission a => Permission -> a -> Handler a

--- a/src/Controller/Permission.hs
+++ b/src/Controller/Permission.hs
@@ -29,6 +29,7 @@ checkPermissionOld requiredPermissionLevel objectWithCurrentUserPermLevel =
 --
 -- This function is probably due for another 3 or 4 rewrites: it's a bit
 -- abstract, serving mostly as a description for its arguments.
+-- TODO: Maybe replace with requestAccess
 checkPermission
     :: (a -> Permission)
     -- ^ How to extract the granted permission for current user

--- a/src/Controller/Record.hs
+++ b/src/Controller/Record.hs
@@ -24,7 +24,7 @@ import Action.Route
 import Action.Response
 import Action
 import Model.Id
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Permission hiding (checkPermission)
 import Model.Record
 import Model.Category

--- a/src/Controller/Upload.hs
+++ b/src/Controller/Upload.hs
@@ -38,7 +38,7 @@ import Service.Log
 import Model.Id
 import Model.Identity (MonadHasIdentity)
 import Model.Permission
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Format
 import Model.Token
 import Store.Upload

--- a/src/Controller/Volume.hs
+++ b/src/Controller/Volume.hs
@@ -310,16 +310,11 @@ viewVolumeEdit :: ActionRoute (Id Volume)
 viewVolumeEdit = action GET (pathHTML >/> pathId </< "edit") $ \_ -> withAuth $ do
   angular
   return (okResponse [] ("" :: String)) -- should never get here
-  {-
-  v <- getVolume PermissionEDIT vi
-  cite <- lookupVolumeCitation v
-  peeks $ blankForm . htmlVolumeEdit (Just (v, cite)) -}
 
 viewVolumeCreateHandler :: Action  -- TODO : GET only
 viewVolumeCreateHandler = withAuth $ do
   angular
   return (okResponse [] ("" :: String)) -- should never get here
-  -- peeks $ blankForm . htmlVolumeEdit Nothing
 
 postVolume :: ActionRoute (Id Volume)
 postVolume = action POST (pathJSON >/> pathId) $ \vi -> withAuth $ do
@@ -330,7 +325,6 @@ postVolume = action POST (pathJSON >/> pathId) $ \vi -> withAuth $ do
   r <- changeVolumeCitation v' cite'
   return $ okResponse [] $
     JSON.recordEncoding $ volumeJSONSimple v' `JSON.foldObjectIntoRec` ("citation" JSON..= if r then cite' else cite)
-    -- HTML -> peeks $ otherRouteResponse [] viewVolume arg
 
 data CreateVolumeRequest =
     CreateVolumeRequest (Maybe (Id Party)) CreateOrUpdateVolumeCitationRequest
@@ -360,15 +354,6 @@ createVolume = action POST (pathJSON >/> "volume") $ \() -> withAuth $ do
       , notificationParty = Just $ partyRow owner
       }
   return $ okResponse [] $ JSON.recordEncoding $ volumeJSONSimple v
-  -- HTML -> peeks $ otherRouteResponse [] viewVolume (api, volumeId $ volumeRow v)
-
-{-
-viewVolumeLinks :: ActionRoute (Id Volume)
-viewVolumeLinks = action GET (pathHTML >/> pathId </< "link") $ \vi -> withAuth $ do
-  v <- getVolume PermissionEDIT vi
-  links <- lookupVolumeLinks v
-  peeks $ blankForm . htmlVolumeLinksEdit v links
--}
 
 newtype UpdateVolumeLinksRequest =
     UpdateVolumeLinksRequest [(T.Text, Maybe URI)]

--- a/src/Controller/VolumeAccess.hs
+++ b/src/Controller/VolumeAccess.hs
@@ -15,7 +15,7 @@ import qualified JSON
 import Model.Id
 import Model.Permission
 import Model.Identity
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.VolumeAccess
 import Model.Party
 import Model.Notification.Types

--- a/src/Controller/VolumeState.hs
+++ b/src/Controller/VolumeState.hs
@@ -11,7 +11,7 @@ import qualified Web.Route.Invertible as R
 import qualified Data.Aeson as Aeson
 import Model.Id
 import Model.Permission
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.VolumeState
 import HTTP.Path.Parser
 import HTTP.Form.Deform

--- a/src/Controller/Zip.hs
+++ b/src/Controller/Zip.hs
@@ -25,7 +25,6 @@ import qualified System.IO as IO
 import qualified System.Directory as DIR
 import qualified Conduit as CND
 import Path (parseRelFile)
--- import Path.IO (resolveFile')
 
 import Ops
 import Has (view, peek, peeks)
@@ -35,7 +34,7 @@ import Store.CSV (buildCSV)
 import Store.Types
 import Model.Id
 import Model.Permission
-import Model.Volume hiding (getVolume)
+import Model.Volume
 import Model.Container
 import Model.Slot
 import Model.RecordSlot
@@ -66,10 +65,6 @@ assetZipEntry2 isOrig containerDir AssetSlot{ slotAsset = a@Asset{ assetRow = ar
                  True -> getAssetFile $ fromJust origAsset
                  False -> getAssetFile a
   req <- peek
-  -- (t, _) <- assetCreation a
-  -- Just (t, s) <- fileInfo f
-  -- liftIO (print ("downloadname", assetDownloadName False True ar))
-  -- liftIO (print ("format", assetFormat ar))
   let entryName =
         containerDir `BS.append` (case isOrig of
           False -> makeFilename (assetDownloadName True False ar) `addFormatExtension` assetFormat ar

--- a/src/Model/Container.hs
+++ b/src/Model/Container.hs
@@ -53,6 +53,8 @@ blankContainer vol = Container
   , containerVolume = vol
   }
 
+-- | Look up a Container by its Id, gated by the running Identity's permission
+-- to view the Volume containing the Container.
 lookupContainer :: (MonadDB c m, MonadHasIdentity c m) => Id Container -> m (Maybe Container)
 lookupContainer ci = do
   ident <- peek

--- a/src/Model/Permission.hs
+++ b/src/Model/Permission.hs
@@ -12,6 +12,9 @@ module Model.Permission
   -- * Checking permissioned objects
   , checkPermission
   , PermissionResponse (..)
+  -- * New
+  , requestAccess
+  , Permissioned (Permissioned)
   ) where
 
 import Data.Monoid ((<>))
@@ -19,6 +22,28 @@ import Data.Monoid ((<>))
 import qualified JSON
 import Model.Release.Types
 import Model.Permission.Types
+
+-- | Represents a permissioned object.
+data Permissioned a = Permissioned
+    { unsafeAccess :: a
+    , grantedPermission :: Permission
+    }
+
+-- | How to get access to a permissioned object. It's not a great design, but it
+-- makes a concrete concept out of an existing pattern in the codebase. A better
+-- design could perhaps couple the access request to the action that needs the
+-- access.
+requestAccess
+    :: Permission
+    -- ^ Requested permission
+    -> Permissioned a
+    -- ^ object
+    -> Maybe a
+    -- ^ Maybe the unwrapped object
+requestAccess requestedPerm obj =
+    if requestedPerm >= grantedPermission obj
+    then Just (unsafeAccess obj)
+    else Nothing
 
 -- |Level at which things become visible. ; TODO: use this somewhere?
 -- permissionVIEW :: Permission

--- a/src/Model/Permission.hs
+++ b/src/Model/Permission.hs
@@ -41,7 +41,7 @@ requestAccess
     -> Maybe a
     -- ^ Maybe the unwrapped object
 requestAccess requestedPerm obj =
-    if requestedPerm >= grantedPermission obj
+    if requestedPerm <= grantedPermission obj
     then Just (unsafeAccess obj)
     else Nothing
 

--- a/src/Model/Permission.hs
+++ b/src/Model/Permission.hs
@@ -14,7 +14,8 @@ module Model.Permission
   , PermissionResponse (..)
   -- * New
   , requestAccess
-  , Permissioned (Permissioned)
+  , Permissioned
+  , mkPermissioned
   ) where
 
 import Data.Monoid ((<>))
@@ -23,11 +24,22 @@ import qualified JSON
 import Model.Release.Types
 import Model.Permission.Types
 
--- | Represents a permissioned object.
+-- | Represents a permissioned object. The constructor is not exported: use
+-- 'mkPermissioned' and 'requestAccess' instead.
 data Permissioned a = Permissioned
     { unsafeAccess :: a
     , grantedPermission :: Permission
     }
+
+-- | Smart constructor for Permissioned.
+--
+-- As one can tell from the first argument, this assumes that objects already
+-- have some way of being mapped to the permissions granted on them. This is
+-- generally true because of how the existing code works. It might change in the
+-- future, for example if database queries return a 'Permissioned' value
+-- directly, obsoleting this function.
+mkPermissioned :: (a -> Permission) -> a -> Permissioned a
+mkPermissioned getPerm o = Permissioned o (getPerm o)
 
 -- | How to get access to a permissioned object. It's not a great design, but it
 -- makes a concrete concept out of an existing pattern in the codebase. A better

--- a/src/Model/Permission.hs
+++ b/src/Model/Permission.hs
@@ -118,11 +118,7 @@ data PermissionResponse a
     -- ^ No.
 
 -- | Decorate some permissioned object with a permission response
--- TODO: Wouldn't it be great if this had type
--- @@Permissioned a -> Permission -> PermissionResponse a@@ ?
---
--- NB: This clashes with 'Controller.Permission.checkPermission', which it
--- should replace.
+-- TODO: Maybe replace with requestAccess
 checkPermission
     :: (a -> Permission) -- ^ Extract the object's permission rules
     -> a -- ^ The object in question

--- a/src/Model/Slot.hs
+++ b/src/Model/Slot.hs
@@ -6,7 +6,6 @@ module Model.Slot
   , slotJSON
   ) where
 
--- import Database.PostgreSQL.Typed (pgSQL)
 import Database.PostgreSQL.Typed.Types
 import qualified Data.String
 

--- a/src/Model/Slot/Types.hs
+++ b/src/Model/Slot/Types.hs
@@ -46,8 +46,6 @@ instance Kinded Slot where
 
 instance Has Container Slot where
   view = slotContainer
-{- instance Has (Id Model.Volume.Types.Volume) Slot where
-  view = (view . slotContainer) -}
 instance Has Model.Permission.Types.Permission Slot where
   view = view . slotContainer
 instance Has Model.Volume.Types.Volume Slot where

--- a/src/Model/Volume.hs
+++ b/src/Model/Volume.hs
@@ -9,8 +9,6 @@ module Model.Volume
     , coreVolume
     , lookupVolume
     , lookupVolumeP
-    , getVolume
-    , LookupResult (..)
     , changeVolume
     , addVolume
     , auditVolumeDownload
@@ -49,41 +47,6 @@ import Model.Volume.Types
 import Model.VolumeAccess.Types (VolumeAccess(..))
 import Service.DB
 import qualified JSON
-
--- | Captures possible database responses.
--- NOTE: This was designed to mimic existing code and responses. LookupFailed
--- does NOT mean "does not exist". It means that 'lookupVolume' (for example)
--- returned Nothing. This could mean either the id is a valid id, or the user
--- doesn't have access to the volume.
-data LookupResult a
-    = LookupFailed
-    | LookupDenied
-    | LookupFound a
-
--- | Get a 'Volume', if it is available to the given 'Identity' with the desired
--- 'Permission'.
-getVolume
-    :: (MonadDB c ctrl, MonadHasIdentity c ctrl)
-    => Permission -- ^ Desired permission level
-    -> Id Volume -- ^ Id of Volume to get
-    -> ctrl (LookupResult Volume)
-getVolume reqestedPermission volId = do
-    mVol <- lookupVolume volId
-    pure $ case mVol of
-        Nothing -> LookupFailed
-        Just vol ->
-            let
-                grantedPermission =
-                    extractPermissionIgnorePolicy . volumeRolePolicy
-            in
-                case
-                    checkPermission
-                        grantedPermission
-                        vol
-                        reqestedPermission
-                of
-                    PermissionGranted v -> LookupFound v
-                    PermissionDenied -> LookupDenied
 
 coreVolume :: Volume
 -- TODO: load on startup in lookups service module

--- a/src/Model/Volume.hs
+++ b/src/Model/Volume.hs
@@ -82,6 +82,7 @@ requestVolume
 requestVolume requestedPerm =
     fmap (maybe LookupFailed mkRequest) . lookupVolumeP
   where
+    mkRequest :: Permissioned Volume -> RequestResult Volume
     mkRequest =
         maybe RequestDenied RequestResult . requestAccess requestedPerm
 
@@ -93,6 +94,7 @@ lookupVolumeP
     -> m (Maybe (Permissioned Volume))
 lookupVolumeP = fmap (fmap wrapPermission) . lookupVolume
   where
+    wrapPermission :: Volume -> Permissioned Volume
     wrapPermission =
         mkPermissioned (extractPermissionIgnorePolicy . volumeRolePolicy)
 

--- a/src/Model/Volume.hs
+++ b/src/Model/Volume.hs
@@ -94,7 +94,7 @@ lookupVolumeP
 lookupVolumeP = fmap (fmap wrapPermission) . lookupVolume
   where
     wrapPermission =
-        Permissioned <*> extractPermissionIgnorePolicy . volumeRolePolicy
+        mkPermissioned (extractPermissionIgnorePolicy . volumeRolePolicy)
 
 lookupVolume
     :: (MonadDB c m, MonadHasIdentity c m) => Id Volume -> m (Maybe Volume)

--- a/src/Model/Volume.hs
+++ b/src/Model/Volume.hs
@@ -9,6 +9,7 @@ module Model.Volume
     , coreVolume
     , lookupVolume
     , lookupVolumeP
+    , requestVolume
     , changeVolume
     , addVolume
     , auditVolumeDownload
@@ -58,6 +59,17 @@ coreVolume = Volume
     )
     []
     (RolePublicViewer PublicNoPolicy)
+
+
+-- | Lookup a Volume by its Id, requesting the given permission.
+requestVolume
+    :: (MonadDB c m, MonadHasIdentity c m)
+    => Permission
+    -> Id Volume
+    -> m (Maybe Volume)
+requestVolume requestedPerm volId = do
+    mv <- lookupVolumeP volId
+    pure (requestAccess requestedPerm =<< mv)
 
 -- | Lookup a 'Volume' by its Id, and wrap it in 'Permissioned'. The plan is for
 -- this to replace 'lookupVolume' entirely.

--- a/src/Model/Volume.hs
+++ b/src/Model/Volume.hs
@@ -8,6 +8,7 @@ module Model.Volume
     ( module Model.Volume.Types
     , coreVolume
     , lookupVolume
+    , lookupVolumeP
     , getVolume
     , LookupResult (..)
     , changeVolume
@@ -94,6 +95,21 @@ coreVolume = Volume
     )
     []
     (RolePublicViewer PublicNoPolicy)
+
+-- | Lookup a 'Volume' by its Id, and wrap it in 'Permissioned'. The plan is for
+-- this to replace 'lookupVolume' entirely.
+lookupVolumeP
+    :: (MonadDB c m, MonadHasIdentity c m)
+    => Id Volume
+    -> m (Maybe (Permissioned Volume))
+lookupVolumeP =
+    fmap
+            (fmap
+                (Permissioned
+                <*> extractPermissionIgnorePolicy . volumeRolePolicy
+                )
+            )
+        . lookupVolume
 
 lookupVolume
     :: (MonadDB c m, MonadHasIdentity c m) => Id Volume -> m (Maybe Volume)

--- a/src/Model/Volume.hs
+++ b/src/Model/Volume.hs
@@ -8,7 +8,6 @@ module Model.Volume
     ( module Model.Volume.Types
     , coreVolume
     , lookupVolume
-    , lookupVolumeP
     , requestVolume
     , RequestResult (..)
     , changeVolume
@@ -85,18 +84,16 @@ requestVolume requestedPerm =
     mkRequest :: Permissioned Volume -> RequestResult Volume
     mkRequest =
         maybe RequestDenied RequestResult . requestAccess requestedPerm
-
--- | Lookup a 'Volume' by its Id, and wrap it in 'Permissioned'. The plan is for
--- this to replace 'lookupVolume' entirely.
-lookupVolumeP
-    :: (MonadDB c m, MonadHasIdentity c m)
-    => Id Volume
-    -> m (Maybe (Permissioned Volume))
-lookupVolumeP = fmap (fmap wrapPermission) . lookupVolume
-  where
+    --
+    lookupVolumeP
+        :: (MonadDB c m, MonadHasIdentity c m)
+        => Id Volume
+        -> m (Maybe (Permissioned Volume))
+    lookupVolumeP = fmap (fmap wrapPermission) . lookupVolume
+    --
     wrapPermission :: Volume -> Permissioned Volume
-    wrapPermission =
-        mkPermissioned (extractPermissionIgnorePolicy . volumeRolePolicy)
+    wrapPermission = mkPermissioned
+        (extractPermissionIgnorePolicy . volumeRolePolicy)
 
 lookupVolume
     :: (MonadDB c m, MonadHasIdentity c m) => Id Volume -> m (Maybe Volume)

--- a/test/Model/TypeOrphans.hs
+++ b/test/Model/TypeOrphans.hs
@@ -21,7 +21,6 @@ import Model.Record.Types
 import Model.Slot.Types
 import Model.Tag.Types
 import Model.Volume.Types
-import Model.Volume (LookupResult (..))
 
 deriving instance Show Age
 
@@ -97,9 +96,6 @@ deriving instance Show Volume
 
 deriving instance Eq VolumeRow
 deriving instance Show VolumeRow
-
-deriving instance Show a => Show (LookupResult a)
-deriving instance Eq a => Eq (LookupResult a)
 
 deriving instance Show a => Show (PermissionResponse a)
 deriving instance Eq a => Eq (PermissionResponse a)

--- a/test/Model/TypeOrphans.hs
+++ b/test/Model/TypeOrphans.hs
@@ -21,6 +21,7 @@ import Model.Record.Types
 import Model.Slot.Types
 import Model.Tag.Types
 import Model.Volume.Types
+import Model.Volume (RequestResult (..))
 
 deriving instance Show Age
 
@@ -96,6 +97,9 @@ deriving instance Show Volume
 
 deriving instance Eq VolumeRow
 deriving instance Show VolumeRow
+
+deriving instance Show a => Show (RequestResult a)
+deriving instance Eq a => Eq (RequestResult a)
 
 deriving instance Show a => Show (PermissionResponse a)
 deriving instance Eq a => Eq (PermissionResponse a)

--- a/test/ModelTest.hs
+++ b/test/ModelTest.hs
@@ -12,7 +12,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as BSLC
--- import qualified Data.HashMap.Strict as HM
 import Data.IORef (readIORef)
 import Data.Maybe
 import Data.Monoid ((<>))
@@ -42,21 +41,17 @@ import Model.Authorize
 import Model.Category
 import Model.Citation
 import Model.Container
--- import Model.Container.TypesTest
 import Model.Factories
 import Model.Format
-import Model.Identity (MonadHasIdentity)
 import Model.Measure
 import Model.Metric
 import Model.Notification
 import Model.Offset
 import Model.Paginate
 import Model.Party
--- import Model.Party.TypesTest
 import Model.Permission
 import Model.Release
 import Model.Record
--- import Model.Record.TypesTest
 import Model.RecordSlot
 import Model.Segment
 import Model.Slot
@@ -64,7 +59,6 @@ import Model.Token
 import Model.Transcode
 import Model.Volume
 import Model.VolumeAccess
--- import Model.VolumeAccess.TypesTest
 import Model.VolumeMetric
 import Service.DB (DBConn, MonadDB)
 import Service.Entropy (initEntropy)
@@ -77,8 +71,6 @@ import Store.AV (initAV)
 import Store.CSV (buildCSV)
 import Store.Types
 import qualified Store.Config as C
--- import Store.Asset
--- import Store.AV
 import Store.Probe
 import Store.Transcode
 import Store.Upload (uploadFile)


### PR DESCRIPTION
Rather than hacking around getVolume or using lookupVolume directly, tests can use requestVolume to get at the model data with particular permissions.

This makes concrete a common pattern in accessing objects. It will be copied for Slots, Containers, and maybe other things?

I added some incidental changes:
* move lookupContainerSlot to the library
* some tweaks to dev tools (more, unmerged changes are queued up)
* ruthless dead code removal