### PR TITLE
Start of fake data generator utility

### DIFF
--- a/app-databrary-load-fake/Main.hs
+++ b/app-databrary-load-fake/Main.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Control.Monad.Trans.Reader
+import Data.Time
+import qualified Network.Wai as Wai
+
+import Has
+import Model.Audit (MonadAudit)
+import Model.Id
+import Model.Identity.Types
+import Model.Party (lookupSiteAuthByEmail)
+import Model.Party.Types
+import Model.Token.Types
+import Model.Volume.Types (Volume(..), VolumeRow(..), blankVolume)
+import Model.Volume (addVolume)
+import Model.VolumeAccess (setDefaultVolumeAccessesForCreated)
+import Service.DB
+
+main :: IO ()
+main = do
+    -- TODO add a test mode where this is wrapped in a transaction
+    ctx <- baseCtxt
+    Just auth <- runReaderT (lookupSiteAuthByEmail False "test@databrary.org") ctx
+    let superAdminAcct = siteAccount auth
+        superAdminCtx = setCtxtIdentInfo ctx auth
+    _ <- (flip runReaderT) superAdminCtx (do
+        addVolumeWithAccess superAdminAcct)
+    print ("Finished adding fake data." :: String)
+
+-- make a volume
+addVolumeWithAccess :: MonadAudit c m => Account -> m Volume
+addVolumeWithAccess a = do
+    let bv = blankVolume
+        v =
+            bv
+                { volumeRow = (volumeRow bv)
+                    { volumeName = "Vol 2"
+                    , volumeBody = Just "Volume two body here"
+                    , volumeAlias = Just "Vol alias"
+                    }
+              }
+    v' <- addVolume v
+    setDefaultVolumeAccessesForCreated (accountParty a) v'
+    pure v'
+
+-- build up parameters for size of data to generate from yaml file
+
+-- make context
+setCtxtIdentInfo :: Ctxt -> SiteAuth -> Ctxt
+setCtxtIdentInfo ctx auth =
+  let
+      pid = (partyId . partyRow . accountParty . siteAccount) auth
+      ident = fakeIdentSessFromAuth auth True
+  in
+      ctx
+          { ctxPartyId = pid
+          , ctxSiteAuth = auth
+          , ctxIdentity = ident
+          }
+
+fakeIdentSessFromAuth :: SiteAuth -> Bool -> Identity
+fakeIdentSessFromAuth a su =
+    Identified
+      (Session
+         (AccountToken (Token (Id "id") (UTCTime (fromGregorian 2017 1 2) (secondsToDiffTime 0))) a)
+         "verf"
+         su)
+
+baseCtxt :: IO Ctxt
+baseCtxt = do
+    cn <- loadPGDatabase >>= pgConnect
+    pure
+        (Ctxt
+             { ctxConn = cn
+             , ctxRequest = Wai.defaultRequest
+             , ctxPartyId = undefined
+             , ctxSiteAuth = undefined
+             , ctxIdentity = undefined
+             })
+
+data Ctxt = Ctxt
+    { ctxRequest :: Wai.Request
+    -- ^ for MonadHasRequest
+    , ctxConn :: DBConn
+    -- ^ MonadDB
+    , ctxPartyId :: Id Party
+    -- ^ for MonadAudit
+    , ctxSiteAuth :: SiteAuth
+    , ctxIdentity :: Identity
+    }
+
+instance Has Wai.Request Ctxt where
+    view = ctxRequest
+
+instance Has DBConn Ctxt where
+    view = ctxConn
+
+instance Has (Id Party) Ctxt where
+    view = ctxPartyId
+
+instance Has SiteAuth Ctxt where
+    view = ctxSiteAuth
+
+instance Has Identity Ctxt where
+    view = ctxIdentity
+

--- a/databrary.cabal
+++ b/databrary.cabal
@@ -417,6 +417,34 @@ Executable databrary
   -- pkgconfig-depends: libavformat, libswscale, libavcodec, libavutil
   -- extra-libraries: crack, crypto
 
+Executable databrary-load-fake
+  hs-source-dirs: app-databrary-load-fake
+  main-is: Main.hs
+
+  build-depends:
+    databrary
+    , base >= 4.8.2.0
+    , aeson
+    -- , array
+    -- , attoparsec
+    -- , bytestring
+    -- , containers
+    -- , mtl
+    -- , postgresql-typed
+    -- , resourcet
+    , transformers
+    -- , text
+    , time
+    -- , unordered-containers
+    -- , vector
+    , wai
+                
+  default-language: Haskell2010
+  default-extensions: MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, ScopedTypeVariables, ConstraintKinds, PatternGuards
+
+  ghc-options: -threaded -Wall
+  ghc-options: -with-rtsopts -N
+  
 Executable generate
   hs-source-dirs: app-generate, src
   main-is: generate.hs


### PR DESCRIPTION
Start defining an executable, which a front end developer or back end developer might use after creating an empty test database on a test server.

## Motivation and Context
As we have long restricted our front end developer's ability to deploy to staging with a fully populated data set, let's at least provide some way to quickly generate fake data in test instances.

This will eventually grow to a few modules, and load the definition of the fake data from yaml files.

## How Has This Been Tested?
Ran it locally, as follows.

Start up database.
Run fake data insertion below.
```
$ nix-shell
> cabal build && dist/build/databrary-load-fake/databrary-load-fake
```
Then, start up your local instance as you normally would.

## Types of changes
<!--- What types of changes does your code introduce? Please delete all entries that do not apply --->
- Devops, scripts

<!--- ## Checklist: --->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

cc: @myicicle 