### PR TITLE
Garbage collect before copy closure instead

### DIFF
--- a/build-package-copy-prep-prod
+++ b/build-package-copy-prep-prod
@@ -7,6 +7,7 @@ rcvr="$usr@databrary.home.nyu.edu"
 echo "building Databrary binaries..."
 # if /tmp is too small for major nix builds, create appropriate dir, then use TMPDIR=... build-package-copy-prep ...
 RESULT="$(nix-build --attr databrary --show-trace)"
+ssh -t "$rcvr" "nix-collect-garbage -d"
 nix-copy-closure --to "$rcvr" "$RESULT"
 echo "copy closure of Databrary binaries completed..."
 
@@ -14,7 +15,6 @@ echo "copy closure of Databrary binaries completed..."
 # NOTE: this is overly complex, simplify using multiple lines later
 ssh -t "$rcvr" " \
            nix-env --install $RESULT \
-        && nix-collect-garbage -d \
         && rm -f /home/databrary/databraryExeLink \
         && ln -s $RESULT/bin/databrary /home/databrary/databraryExeLink \
 "

--- a/build-package-copy-prep-stage
+++ b/build-package-copy-prep-stage
@@ -7,6 +7,7 @@ rcvr="$usr@databrary2.home.nyu.edu"
 echo "building Databrary binaries..."
 # if /tmp is too small for major nix builds, create appropriate dir, then use TMPDIR=... build-package-copy-prep ...
 RESULT="$(nix-build --attr databrary --show-trace --keep-failed --cores 4)"
+ssh -t "$rcvr" "nix-collect-garbage -d"
 nix-copy-closure --to "$rcvr" "$RESULT"
 echo "copy closure of Databrary binaries completed..."
 
@@ -14,7 +15,6 @@ echo "copy closure of Databrary binaries completed..."
 # NOTE: this is overly complex, simplify using multiple lines later
 ssh -t "$rcvr" " \
            nix-env --install $RESULT \
-        && nix-collect-garbage -d \
         && rm -f /home/demo/databraryExeLink \
         && ln -s $RESULT/bin/databrary /home/demo/databraryExeLink \
 "


### PR DESCRIPTION
garbage collect before copy closure during deploy, instead of after installing new derivation on target server

## Motivation and Context
garbage collecting later on was probably deleting the previous derivation. that might have been safe, if there was only an executable involved, but the derivation also contains static assets that are loaded on demand into the web server. those static assets were probably deleted, leaving images and css files missing. (one can only observe this on the server, as most users will have the css and images cached)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
ran a deploy to staging

## Types of changes
<!--- What types of changes does your code introduce? Please delete all entries that do not apply --->
- Devops, scripts

<!--- ## Checklist: --->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->