### PR TITLE
Add repl/ghcid scripts

### DIFF
--- a/s/ghcid-lib
+++ b/s/ghcid-lib
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# Loads the library in ghcid
+#
+# Just to keep things interesting, ghcid is run within nix-shell, which both
+# makes sure ghcid is available, and makes sure cabal can access library
+# dependencies.
+
+nix-shell --option binary-caches "https://cache.nixos.org http://devdatabrary2.home.nyu.edu:5000" \
+    --run 'ghcid -c "cabal repl --ghc-options=\"-Wno-deprecations -Wno-overlapping-patterns\" lib:databrary"'

--- a/s/ghcid-test
+++ b/s/ghcid-test
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# Repeatedly loads and runs the test suite in ghcid.
+#
+# There are two levels to this. On the outer level, entr reloads ghcid whenever
+# files change in src, since cabal repl won't notice them. On the inner level,
+# ghcid runs :reload when test source files change.
+#
+# Just to keep things interesting, ghcid is run within nix-shell, which both
+# makes sure ghcid is available, and makes sure cabal can access library
+# dependencies.
+
+find src -regex '.*\.l?hsc?' \
+    | entr -scdr "nix-shell --option binary-caches \"https://cache.nixos.org http://devdatabrary2.home.nyu.edu:5000\" \
+        --run 'ghcid -c \"cabal repl test:discovered\" -T \":run Main.main --hide-successes --timeout 1s\"'"

--- a/s/repl-lib
+++ b/s/repl-lib
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# Loads the library in the repl.
+
+nix-shell --option binary-caches "https://cache.nixos.org http://devdatabrary2.home.nyu.edu:5000" \
+    --run 'cabal repl lib:databrary'


### PR DESCRIPTION
These are scripts I have been using to quick-load both the lib and tests. I have a tmux workflow that uses *three* running interpreters, running all three of these scripts.

See script comments for further docs.

To do?
* Remove Makefile targets that these scripts deprecate.