### PR TITLE
Broaden DOI regex to new resolver

### DIFF
--- a/web/service/constant.js
+++ b/web/service/constant.js
@@ -15,7 +15,7 @@ app.factory('constantService', [
     constants.messages = messages;
 
     constants.regex = {
-      doi: /^(?:[dD][oO][iI]:|[hH][dD][lL]:|(?:http:\/\/)?dx\.doi\.org\/)?(10\.[0-9\.]+\/\S+)\s*$/,
+      doi: /^(?:[dD][oO][iI]:|[hH][dD][lL]:|(?:https?:\/\/)?(dx\.)?doi\.org\/)?(10\.[0-9\.]+\/\S+)\s*$/,
     };
 
     //


### PR DESCRIPTION
This updates your DOI regex to also match the new, `https` but non-`dx` URLs.

## Motivation and Context

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

## How Has This Been Tested?

Not, because it's only link changes.

## Types of changes

- Refactor, maybe

<!--- ## Checklist: --->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
