### PR TITLE
Fix broken links in home.html

### DIFF
--- a/web/site/home.html
+++ b/web/site/home.html
@@ -46,7 +46,7 @@
           indefinitely. With participant permission, you can then choose to <a
             href="https://www.databrary.org/resources/data-sharing-manifesto.html">share your research with the
             Databrary community</a>.</p>
-        <p><a href="https://www.databrary.org/resources/guide/investigators/contributing.html">Get more information</a>,
+        <p><a href="https://www.databrary.org/support.html">Get more information </a>,
           and login or register now to get started.</p>
       </div>
       <div class="four-recs">
@@ -76,8 +76,7 @@
           <li>improves scientific practices by increasing transparency and reproducibility, and</li>
           <li>expands our influence as researchers.</li>
         </ul>
-        <p>Read Databrary's <a href="https://www.databrary.org/resources/data-sharing-manifesto.html">Data Sharing
-            Manifesto</a>, and login or register now to get started.</p>
+        <p>Login or register now to get started.</p>
       </div>
     </div>
     <div class="arrow-container"><a class="arrow-a" href="#"><span class="accessible-hidden">Arrow down to the next


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix broken links in Archive Data and Share Data panels on Databrary's home page.

<!--- Describe your changes in detail -->

Deleted the reference to the Data Sharing Manifesto; changed a link to point to https://databrary.org/support.html.

## Motivation and Context

Fixes broken links

## How Has This Been Tested?

Not tested.

## Types of changes
<!--- What types of changes does your code introduce? Please delete all entries that do not apply --->
- Style, layout change

