### PR TITLE
Update register.html by fixing links to appropriate policy docs

### DIFF
--- a/web/party/register.html
+++ b/web/party/register.html
@@ -42,7 +42,7 @@
                 <li>Respect participants' wishes about sharing their data just as you do in your lab.</li>
                 <li>Take care in authorizing other people (affiliates and collaborators) and take responsibility for their conduct and use of Databrary data, just as you do in your own lab.</li>
               </ol>
-              <p>Read the <a href="http://databrary.org/access/policies/agreement.html" target="_blank">Databrary Access Agreement</a>. You can also download the <a href="http://databrary.org/policies/agreement.pdf" target="_blank">full agreement as pdf</a>.</p>
+              <p>Read the <a href="https://databrary.org/about/agreement/agreement.html" target="_blank">Databrary Access Agreement</a> and <a href="https://databrary.org/about/agreement/agreement-annex-I.html" target="_blank">Annex I -- Statement of Rights and Responsibilities</a>. You can also download a <a href="https://databrary.org/policies/agreement.pdf" target="_blank">pdf of the agreement</a> and the <a href="https://databrary.org/policies/agreement-annex-I.pdf" target="_blank">Statement of Rights and Responsibilities</a>.</p>
             </div>
 
             <p>


### PR DESCRIPTION
Fixed links on "Get Started" page of registration process.

## Motivation and Context

Current page has a broken URL. Link to PDF works but only links to Access Agreement. New users should also read Annex I.

## How Has This Been Tested?

Not tested.

## Types of changes
- Bug fix
