### PR TITLE
Disable google map block from home page

### DIFF
--- a/web/site/home.html
+++ b/web/site/home.html
@@ -310,9 +310,9 @@
   </div>
   <!--stat ends-->
   <!--map begins-->
-  <div id="map_wrapper">
+  <!-- <div id="map_wrapper">
     <div id="map_canvas" class="mapping"></div>
-  </div>
+  </div> -->
   <div class="sponsors">
     <div>
       <a href="http://www.nyu.edu">


### PR DESCRIPTION
Temporarily hide the Google map on the Home page until we decide if we are renewing the Google map API key or using an open-source alternative.