### PR TITLE
Update Nix 2.0 install script URL to a working one

### DIFF
--- a/setup-nix/1.sh
+++ b/setup-nix/1.sh
@@ -4,7 +4,7 @@ set -eu
 echo "Manually running nix/install script, fixed to nix 2.0 currently"
 # curl https://nixos.org/nix/install | sh
 cd /tmp
-curl -o install-2.0 https://raw.githubusercontent.com/NixOS/nixos-homepage/master/nix/install-2.0
+curl -o install-2.0 https://releases.nixos.org/nix/nix-2.0/install
 chmod +x install-2.0
 sh ./install-2.0
 


### PR DESCRIPTION
The nix setup script uses an URL that does not work any more. Update the URL in this PR to the Nix releases site.

## Motivation and Context

Fixes the Nix install script.

## How Has This Been Tested?

Ran locally and it works

## Types of changes

- Bug fix
