### PR TITLE
Fix http://gitcdn.link failure

### DIFF
--- a/src/View/Angular.hs
+++ b/src/View/Angular.hs
@@ -93,9 +93,9 @@ htmlAngular assetsVersion cssDeps jsDeps nojs reqCtx = H.docTypeHtml H.! ngAttri
     H.preEscapedString "<toolbar></toolbar>"
     H.script H.! HA.src "https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" H.! H.customAttribute "integrity" "sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" H.! H.customAttribute  "crossorigin" "" 
       $ return ()
-    H.script H.! HA.src "https://gitcdn.link/cdn/leaflet-extras/leaflet-providers/master/leaflet-providers.js" 
+    H.script H.! HA.src "https://raw.githubusercontent.com/leaflet-extras/leaflet-providers/master/leaflet-providers.js" 
       $ return ()
-    H.script H.! HA.src "https://gitcdn.link/cdn/gilmore-lab/databrary-analytics/master/institutions-investigators/js/institutions.js"
+    H.script H.! HA.src "https://raw.githubusercontent.com/gilmore-lab/databrary-analytics/master/institutions-investigators/js/institutions.js"
       $ return ()
     H.preEscapedString $ "<main ng-view id=\"main\" class=\"main"
 #ifdef SANDBOX

--- a/src/View/Angular.hs
+++ b/src/View/Angular.hs
@@ -93,9 +93,9 @@ htmlAngular assetsVersion cssDeps jsDeps nojs reqCtx = H.docTypeHtml H.! ngAttri
     H.preEscapedString "<toolbar></toolbar>"
     H.script H.! HA.src "https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" H.! H.customAttribute "integrity" "sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" H.! H.customAttribute  "crossorigin" "" 
       $ return ()
-    H.script H.! HA.src "https://raw.githubusercontent.com/leaflet-extras/leaflet-providers/master/leaflet-providers.js" 
+    H.script H.! HA.src "https://cdn.statically.io/gh/leaflet-extras/leaflet-providers/d5dc3dec/leaflet-providers.js" 
       $ return ()
-    H.script H.! HA.src "https://raw.githubusercontent.com/gilmore-lab/databrary-analytics/master/institutions-investigators/js/institutions.js"
+    H.script H.! HA.src "https://cdn.statically.io/gh/gilmore-lab/databrary-analytics/96ce5a60/institutions-investigators/js/institutions.js"
       $ return ()
     H.preEscapedString $ "<main ng-view id=\"main\" class=\"main"
 #ifdef SANDBOX


### PR DESCRIPTION
gitcdn.{link,xyz} has failed. The service supported the Leaflet map on the Databrary homepage. 

To fix, I replaced the relevant path components with raw.githubusercontent.com.

## Motivation and Context

No map is being displayed.

## How Has This Been Tested?

The map generation has _not_ been tested, but the links to the supporting files _have_ been tested.

## Types of changes
- Bug fix
