### PR TITLE
changed sbatch mem to 1.5GB

### DIFF
--- a/transcode
+++ b/transcode
@@ -4,7 +4,7 @@
 # It is also the SLURM script so is in fact run twice, once with arguments (up to the sbatch), once with variables.
 
 #SBATCH --nodes=1
-#SBATCH --mem=1024m 
+#SBATCH --mem=1536m 
 
 SLURM=$0
 if [[ $SLURM != /* ]] ; then


### PR DESCRIPTION
4k video (720p stacked in a 3x3 grid) transcode jobs fail with exit code 137 (OOM).

Changed `sbatch` mem alloc to 1.5GB.
